### PR TITLE
Twitter semantic network update 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vosonSML
-Version: 0.27.0
+Version: 0.27.1
 Title: Collecting Social Media Data and Generating Networks for Analysis
 Description: A suite of tools for collecting and constructing networks from social media data.
     Provides easy-to-use functions for collecting data across popular platforms (Twitter, YouTube 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# vosonSML 0.27.1
+
+## Bug Fixes
+- Fixed a bug in `Create.semantic.twitter` in which a sum operation calculating edge
+  weights would set `NA` values for all edges due to `NA` values present in the hashtag fields. 
+  This occurs when there are tweets with no hashtags in the twitter collection and is now
+  checked.
+- Some UTF encoding issues in `Create.semantic.twitter` were also fixed. 
+
+## Minor Changes
+- Added '#' to hashtags and '@' to mentions in twitter semantic network to differentiate between
+  hashtags, mentions and common terms.
+
 # vosonSML 0.27.0
 
 ## Bug Fixes

--- a/R/Create.semantic.twitter.R
+++ b/R/Create.semantic.twitter.R
@@ -53,7 +53,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   
   df <- datasource # match the variable names (this must be used to avoid warnings in package compilation)
   
-  # if `df` is a list of dataframes, then need to convert these into one dataframe
+  # if df is a list of dataframes, then need to convert these into one dataframe
   suppressWarnings(
     if (class(df) == "list") {
       df <- do.call("rbind", df)
@@ -67,18 +67,21 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   cat("Generating twitter semantic network...\n")
   flush.console()
   
-  # df$hashtags <- lapply(df$hashtags, function(x) paste("#", x))
+  # added hash to hashtags to identify and merge them in results
+  df$hashtags <- lapply(df$hashtags, function(x) ifelse(is.na(x), NA, paste0("#", x)))
   
   # convert the hashtags to lowercase here (before using tm_map later) but first deal with character encoding
-  if (isMac()) {
-    df$hashtags <- lapply(df$hashtags, function(x) TrimOddCharMac(x))
-    df$hashtags <- lapply(df$hashtags, tolower)
-    df$text <- iconv(df$text, to = "utf-8-mac")
-  } else {
-    df$hashtags <- lapply(df$hashtags, function(x) TrimOddChar(x))
-    df$hashtags <- lapply(df$hashtags, tolower)
-    df$text <- iconv(df$text, to = "utf-8")
-  }
+  # if (isMac()) {
+  #   df$hashtags <- lapply(df$hashtags, function(x) TrimOddCharMac(x))
+  #   # df$text <- iconv(df$text, to = "utf-8-mac")
+  # } else {
+  #   df$hashtags <- lapply(df$hashtags, function(x) TrimOddChar(x))
+  #   # df$text <- iconv(df$text, to = "utf-8")
+  # }
+  
+  # and then convert to lowercase
+  df$text <- tolower(df$text)
+  df$hashtags <- lapply(df$hashtags, tolower)
   
   # macMatch <- grep("darwin", R.Version()$os)
   # if (length(macMatch) != 0) {
@@ -103,10 +106,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   # if (length(macMatch) == 0) {
   #   df$text <- iconv(df$text, to = "utf-8")
   # }
-  
-  # and then convert to lowercase
-  df$text <- tolower(df$text)
-  
+
   hashtagsUsedTemp <- c() # temp var to store output
   
   # the 'hashtags_used' column in the 'df' dataframe is slightly problematic (i.e. not straightforward)
@@ -115,17 +115,20 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   # so, need to extract each list item out, and put it into its own row in a new dataframe
   count <- 0
   for (i in 1:nrow(df)) {
-    if (length(df$hashtags[[i]]) > 0) { # skip any rows where NO HASHTAGS were used
+    if (!is.na(df$hashtags[[i]]) && length(df$hashtags[[i]]) > 0) { # skip any rows where NO HASHTAGS were used
       for (j in 1:length(df$hashtags[[i]])) {
         count <- count + 1
         #commonTermsTemp <- c(commonTermsTemp, df$from_user[i])
-        hashtagsUsedTemp <- c(hashtagsUsedTemp, df$hashtags[[i]][j])
+        if (!is.na(df$hashtags[[i]][j])) {
+          hashtagsUsedTemp <- c(hashtagsUsedTemp, df$hashtags[[i]][j]) 
+        }
       }
     }
   } # try and vectorise this in future work to improve speed
   df_stats <- networkStats(df_stats, "raw hashtags", count, FALSE)
   
   hashtagsUsedTemp <- unique(hashtagsUsedTemp)
+  unique_hashtags <- hashtagsUsedTemp
   df_stats <- networkStats(df_stats, "unique hashtags", length(hashtagsUsedTemp), FALSE)
   
   hashtagsUsedTempFrequency <- c()
@@ -145,7 +148,15 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   df_stats <- networkStats(df_stats, paste0("top ", hashtagFreq , "% hashtags"), length(hashtagsUsedTemp), FALSE)
   
   # we need to remove all punctuation EXCEPT HASHES (!) (e.g. both #auspol and auspol will appear in data)
-  df$text <- gsub("[^[:alnum:][:space:]#]", "", df$text)
+  
+  # this is a decision point for non-english text
+  # df$text <- gsub("[^[:alnum:][:space:]#]", "", df$text)
+  
+  # remove urls so dont get weird strings after punctuation removal
+  df$text <- gsub("https://t.co/[a-zA-Z0-9]+\\s", "", df$text, ignore.case = TRUE, perl = TRUE)
+  
+  # remove punctuation except # and @
+  df$text <- gsub("([#@])|[[:punct:]]", "\\1", df$text)
   
   # find the most frequent terms across the tweet text corpus
   commonTermsTemp <- df$text
@@ -153,37 +164,29 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   corpusTweetText <- Corpus(VectorSource(commonTermsTemp))
   
   # add usernames to stopwords
-  mach_usernames <- sapply(df$screen_name, function(x) TrimOddChar(x))
-  mach_usernames <- unique(mach_usernames)
+  # mach_usernames <- sapply(df$screen_name, function(x) TrimOddChar(x))
+  mach_usernames <- unique(df$screen_name)
   
-  if (isMac()) {
-    mach_usernames <- iconv(mach_usernames, to = "utf-8-mac")
-  } else {
-    mach_usernames <- iconv(mach_usernames, to = "utf-8")
-  }
-  
-  # if (length(macMatch) != 0) {
+  # if (isMac()) {
   #   mach_usernames <- iconv(mach_usernames, to = "utf-8-mac")
-  # }
-  # 
-  # if (length(macMatch) == 0) {
+  # } else {
   #   mach_usernames <- iconv(mach_usernames, to = "utf-8")
   # }
-  
+
   # we remove the usernames from the text (so they don't appear in data/network)
   my_stopwords <- mach_usernames
-  corpusTweetText <- tm_map(corpusTweetText, removeWords, my_stopwords)
+  # corpusTweetText <- suppressWarnings(tm_map(corpusTweetText, removeWords, my_stopwords))
   
   # convert to all lowercase (WE WILL DO THIS AGAIN BELOW, SO REMOVE THIS DUPLICATE)
   # corpusTweetText <- tm_map(corpusTweetText, content_transformer(tolower))
   
   # remove English stop words (IF THE USER HAS SPECIFIED!)
   if (stopwordsEnglish) {
-    corpusTweetText <- tm_map(corpusTweetText, removeWords, stopwords("english"))
+    corpusTweetText <- suppressWarnings(tm_map(corpusTweetText, removeWords, stopwords("english")))
   }
   
   # eliminate extra whitespace
-  corpusTweetText <- tm_map(corpusTweetText, stripWhitespace)
+  corpusTweetText <- suppressWarnings(tm_map(corpusTweetText, stripWhitespace))
   
   # create document term matrix applying some transformations
   # ** applying too many transformations here (duplicating...) - need to fix
@@ -198,10 +201,10 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   ## the default finds top 5% terms
   commonTerms <- names(head(vTemp, (length(vTemp) / 100) * termFreq))
   
-  toDel <- grep("http", commonTerms) # !! still picking up junk terms (FIX)
-  if (length(toDel) > 0) {
-    commonTerms <- commonTerms[-toDel] # delete these junk terms
-  }
+  # toDel <- grep("http", commonTerms) # !! still picking up junk terms (FIX)
+  # if (length(toDel) > 0) {
+  #   commonTerms <- commonTerms[-toDel] # delete these junk terms
+  # }
   df_stats <- networkStats(df_stats, paste0("top ", termFreq , "% terms"), length(commonTerms), FALSE)
   
   # create the "semantic hashtag-term network" dataframe (i.e. pairs of hashtags / terms)
@@ -210,7 +213,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   hashtagAssociatedWithTerm <- c() # temp var to store output
   
   for (i in 1:nrow(df)) {
-    if (length(df$hashtags[[i]]) > 0) { # skip any rows where NO HASHTAGS were used
+    if (!is.na(df$hashtags[[i]]) && length(df$hashtags[[i]]) > 0) { # skip any rows where NO HASHTAGS were used
       for (j in 1:length(df$hashtags[[i]])) {
         for (k in 1:length(commonTerms)) {
           
@@ -247,7 +250,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   for (i in 1:nrow(unique_dfSemanticNetwork3)) {
     unique_dfSemanticNetwork3$numHashtagTermOccurrences[i] <- sum(
       hashtagAssociatedWithTerm == unique_dfSemanticNetwork3[i, 1] & 
-        termAssociatedWithHashtag == unique_dfSemanticNetwork3[i, 2], na.rm = TRUE)
+        termAssociatedWithHashtag == unique_dfSemanticNetwork3[i, 2]) # na.rm = TRUE
   }
   
   # make a dataframe of the relations between actors

--- a/R/Create.semantic.twitter.R
+++ b/R/Create.semantic.twitter.R
@@ -67,30 +67,42 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   cat("Generating twitter semantic network...\n")
   flush.console()
   
+  # df$hashtags <- lapply(df$hashtags, function(x) paste("#", x))
+  
   # convert the hashtags to lowercase here (before using tm_map later) but first deal with character encoding
-  macMatch <- grep("darwin", R.Version()$os)
-  if (length(macMatch) != 0) {
-    # df$hashtags_used <- iconv(df$hashtags_used, to = "utf-8-mac")
+  if (isMac()) {
     df$hashtags <- lapply(df$hashtags, function(x) TrimOddCharMac(x))
+    df$hashtags <- lapply(df$hashtags, tolower)
+    df$text <- iconv(df$text, to = "utf-8-mac")
+  } else {
+    df$hashtags <- lapply(df$hashtags, function(x) TrimOddChar(x))
+    df$hashtags <- lapply(df$hashtags, tolower)
+    df$text <- iconv(df$text, to = "utf-8")
   }
   
-  if (length(macMatch) == 0) {
-    df$hashtags <- lapply(df$hashtags, function(x) TrimOddChar(x))
-  }
+  # macMatch <- grep("darwin", R.Version()$os)
+  # if (length(macMatch) != 0) {
+  #   # df$hashtags_used <- iconv(df$hashtags_used, to = "utf-8-mac")
+  #   df$hashtags <- lapply(df$hashtags, function(x) TrimOddCharMac(x))
+  # }
+  # 
+  # if (length(macMatch) == 0) {
+  #   df$hashtags <- lapply(df$hashtags, function(x) TrimOddChar(x))
+  # }
   
   # and then convert to lowercase
-  df$hashtags <- lapply(df$hashtags, tolower)
+  # df$hashtags <- lapply(df$hashtags, tolower)
   
   # do the same for the comment text, but first deal with character encoding!
   # we need to change value of `to` argument in 'iconv' depending on OS, or else errors can occur
-  macMatch <- grep("darwin", R.Version()$os)
-  if (length(macMatch) != 0) {
-    df$text <- iconv(df$text, to = "utf-8-mac")
-  }
-  
-  if (length(macMatch) == 0) {
-    df$text <- iconv(df$text, to = "utf-8")
-  }
+  # macMatch <- grep("darwin", R.Version()$os)
+  # if (length(macMatch) != 0) {
+  #   df$text <- iconv(df$text, to = "utf-8-mac")
+  # }
+  # 
+  # if (length(macMatch) == 0) {
+  #   df$text <- iconv(df$text, to = "utf-8")
+  # }
   
   # and then convert to lowercase
   df$text <- tolower(df$text)
@@ -144,13 +156,19 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   mach_usernames <- sapply(df$screen_name, function(x) TrimOddChar(x))
   mach_usernames <- unique(mach_usernames)
   
-  if (length(macMatch) != 0) {
+  if (isMac()) {
     mach_usernames <- iconv(mach_usernames, to = "utf-8-mac")
-  }
-  
-  if (length(macMatch) == 0) {
+  } else {
     mach_usernames <- iconv(mach_usernames, to = "utf-8")
   }
+  
+  # if (length(macMatch) != 0) {
+  #   mach_usernames <- iconv(mach_usernames, to = "utf-8-mac")
+  # }
+  # 
+  # if (length(macMatch) == 0) {
+  #   mach_usernames <- iconv(mach_usernames, to = "utf-8")
+  # }
   
   # we remove the usernames from the text (so they don't appear in data/network)
   my_stopwords <- mach_usernames
@@ -229,7 +247,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   for (i in 1:nrow(unique_dfSemanticNetwork3)) {
     unique_dfSemanticNetwork3$numHashtagTermOccurrences[i] <- sum(
       hashtagAssociatedWithTerm == unique_dfSemanticNetwork3[i, 1] & 
-        termAssociatedWithHashtag == unique_dfSemanticNetwork3[i, 2])
+        termAssociatedWithHashtag == unique_dfSemanticNetwork3[i, 2], na.rm = TRUE)
   }
   
   # make a dataframe of the relations between actors
@@ -277,6 +295,7 @@ Create.semantic.twitter <- function(datasource, type, removeTermsOrHashtags = NU
   flush.console()
   
   func_output <- list(
+    "relations" = relations,
     "graph" = g
   )
   

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -136,3 +136,13 @@ collectTocOutput <- function(tic, toc, msg) {
   t <- trimws(paste0(t, hrs, " hrs ", mins, " mins ", secs, " secs (", round(toc - tic, digits = 3) , ")"))
 }
 
+# check if R is running on macos
+isMac <- function() {
+  macMatch <- grep("darwin", R.Version()$os)
+  
+  if (length(macMatch) != 0) {
+    return(TRUE)
+  }
+  return(FALSE)
+}
+

--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ The following usage examples will provide a great introduction to using `vosonSM
 
 The process of authentication, data collection and creating social network in vosonSML is expressed with the three verb functions: *Authenticate*, *Collect* and *Create*. The following are some examples:
 
+#### Twitter Examples
 ```R
 library(magrittr)
 library(vosonSML)
-
-# -- Twitter Example --
 
 # Authenticate with twitter, Collect 100 tweets for the '#auspol' hashtag and Create an actor and 
 # semantic network
@@ -77,8 +76,13 @@ actorNetWithUserAttr <- AddTwitterUserData(twitterData, actorNetwork,
 actorGraphWithUserAttr <- actorNetWithUserAttr$graph # igraph network graph
 
 semanticNetwork <- twitterData %>% Create("semantic", writeToFile = TRUE)
+```
 
-# -- Youtube Example --
+#### Youtube Examples
+
+```R
+library(magrittr)
+library(vosonSML)
 
 # Authenticate with youtube, Collect comment data from videos and then Create an actor network
 myYoutubeAPIKey <- "xxxxxxxxxxxxxx"
@@ -89,8 +93,13 @@ myYoutubeVideoIds <- GetYoutubeVideoIDs(c("https://www.youtube.com/watch?v=xxxxx
 actorNetwork <- Authenticate("youtube", apiKey = myYoutubeAPIKey) %>%
                 Collect(videoIDs = myYoutubeVideoIds) %>%
                 Create("actor", writeToFile = TRUE)
+```
 
-# -- Reddit Example --
+#### Reddit Examples
+
+```R
+library(magrittr)
+library(vosonSML)
 
 # Collect reddit comment threads and Create an actor network with comment text as edge attribute
 myThreadUrls <- c("https://www.reddit.com/r/xxxxxx/comments/xxxxxx/x_xxxx_xxxxxxxxx/")
@@ -99,9 +108,11 @@ actorNetwork <- Authenticate("reddit") %>%
                 Collect(threadUrls = myThreadUrls, waitTime = 5) %>%
                 Create("actor", includeTextData = TRUE, writeToFile = TRUE)
 
-             
-# Optional save and load authentication objects from file using saveRDS, readRDS
+```
 
+#### Save and Load Authentication Objects
+
+```R
 # Save the object after Authenticate 
 saveRDS(my_twitter_auth, file = "~/.twitter_auth")
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/extra.css
+++ b/docs/extra.css
@@ -11,7 +11,7 @@ h3, .h3 {
 } 
 
 h4, .h4, h5, .h5 {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .contents h1, .contents h2 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 
@@ -85,9 +85,9 @@
       
       </header><div class="row">
   <div class="contents col-md-9">
-<div id="vosonsml" class="section level1">
+<div id="vosonsml-" class="section level1">
 <div class="page-header"><h1 class="hasAnchor">
-<a href="#vosonsml" class="anchor"></a>vosonSML <img src="reference/figures/logo.png" width="140px" align="right">
+<a href="#vosonsml-" class="anchor"></a>vosonSML <img src="reference/figures/logo.png" width="140px" align="right">
 </h1></div>
 <p><img src="https://img.shields.io/github/release-pre/vosonlab/vosonSML.svg?logo=github&amp;colorB=8065ac" alt="Github Release"><img src="https://img.shields.io/github/last-commit/vosonlab/vosonSML.svg" alt="Last Commit"><a href="https://CRAN.R-project.org/package=vosonSML"><img src="https://www.r-pkg.org/badges/version/vosonSML" alt="CRAN_Status_Badge"></a> <img src="https://cranlogs.r-pkg.org/badges/vosonSML" alt="Downloads"></p>
 <p><code>vosonSML</code> is an R package that provides a suite of tools for collecting and constructing networks from social media data. It provides easy-to-use functions for collecting data across popular platforms and generating different types of networks for analysis.</p>
@@ -103,15 +103,15 @@
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
 <p>Install the current version from Github:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># github installation requires the 'devtools' or 'remotes' package</span>
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(devtools)
-
-<span class="co"># optionally add the parameter 'dependencies = TRUE' to install package dependencies</span>
-devtools<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"vosonlab/vosonSML"</span>)</code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" title="1"><span class="co"># github installation requires the 'devtools' or 'remotes' package</span></a>
+<a class="sourceLine" id="cb1-2" title="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(devtools)</a>
+<a class="sourceLine" id="cb1-3" title="3"></a>
+<a class="sourceLine" id="cb1-4" title="4"><span class="co"># optionally add the parameter 'dependencies = TRUE' to install package dependencies</span></a>
+<a class="sourceLine" id="cb1-5" title="5">devtools<span class="op">::</span><span class="kw">install_github</span>(<span class="st">"vosonlab/vosonSML"</span>)</a></code></pre></div>
 <p>Install vosonSML from CRAN:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/install.packages">install.packages</a></span>(<span class="st">"vosonSML"</span>, <span class="dt">dependencies =</span> <span class="ot">TRUE</span>)</code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" title="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/install.packages">install.packages</a></span>(<span class="st">"vosonSML"</span>, <span class="dt">dependencies =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
 <p>Note about previous releases: The vosonSML package was previously in a subdirectory, so if you wish to install versions prior to <code>0.26</code> please remember to include the <code>subdir</code> parameter.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">devtools<span class="op">::</span><span class="kw"><a href="https://www.rdocumentation.org/packages/devtools/topics/reexports">install_github</a></span>(<span class="st">"vosonlab/vosonSML@v0.25.0"</span>, <span class="dt">subdir =</span> <span class="st">"vosonSML"</span>)</code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" title="1">devtools<span class="op">::</span><span class="kw">install_github</span>(<span class="st">"vosonlab/vosonSML@v0.25.0"</span>, <span class="dt">subdir =</span> <span class="st">"vosonSML"</span>)</a></code></pre></div>
 </div>
 <div id="getting-started" class="section level2">
 <h2 class="hasAnchor">
@@ -121,68 +121,78 @@ devtools<span class="op">::</span><span class="kw"><a href="https://www.rdocumen
 <h3 class="hasAnchor">
 <a href="#usage" class="anchor"></a>Usage</h3>
 <p>The process of authentication, data collection and creating social network in vosonSML is expressed with the three verb functions: <em>Authenticate</em>, <em>Collect</em> and <em>Create</em>. The following are some examples:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(vosonSML)
-
-<span class="co"># -- Twitter Example --</span>
-
-<span class="co"># Authenticate with twitter, Collect 100 tweets for the '#auspol' hashtag and Create an actor and </span>
-<span class="co"># semantic network</span>
-myKeys &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">appName =</span> <span class="st">"vosonSML"</span>, <span class="dt">apiKey =</span> <span class="st">"xxxxxxxxxxxx"</span>, <span class="dt">apiSecret =</span> <span class="st">"xxxxxxxxxxxx"</span>, 
-               <span class="dt">accessToken =</span> <span class="st">"xxxxxxxxxxxx"</span>, <span class="dt">accessTokenSecret =</span> <span class="st">"xxxxxxxxxxxx"</span>)
-  
-twitterAuth &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"twitter"</span>, <span class="dt">appName =</span> myKeys<span class="op">$</span>appName, <span class="dt">apiKey =</span> myKeys<span class="op">$</span>apiKey, 
-                            <span class="dt">apiSecret =</span> myKeys<span class="op">$</span>apiSecret, <span class="dt">accessToken =</span> myKeys<span class="op">$</span>accessToken,
-                            <span class="dt">accessTokenSecret =</span> myKeys<span class="op">$</span>accessTokenSecret)
-                             
-twitterData &lt;-<span class="st"> </span>twitterAuth <span class="op">%&gt;%</span>
-<span class="st">               </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">searchTerm =</span> <span class="st">"#auspol"</span>, <span class="dt">searchType =</span> <span class="st">"recent"</span>, <span class="dt">numTweets =</span> <span class="dv">100</span>, 
-                       <span class="dt">includeRetweets =</span> <span class="ot">FALSE</span>, <span class="dt">retryOnRateLimit =</span> <span class="ot">TRUE</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>, 
-                       <span class="dt">verbose =</span> <span class="ot">TRUE</span>)
-
-actorNetwork &lt;-<span class="st"> </span>twitterData <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>, <span class="dt">verbose =</span> <span class="ot">TRUE</span>)
-
-actorGraph &lt;-<span class="st"> </span>actorNetwork<span class="op">$</span>graph <span class="co"># igraph network graph</span>
-
-<span class="co"># Optional step to add additional twitter user info to actor network graph as node attributes </span>
-actorNetWithUserAttr &lt;-<span class="st"> </span><span class="kw"><a href="reference/vosonSML-colon-colon-AddTwitterUserData.html">AddTwitterUserData</a></span>(twitterData, actorNetwork,
-                                           <span class="dt">lookupUsers =</span> <span class="ot">TRUE</span>, 
-                                           <span class="dt">twitterAuth =</span> twitterAuth, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)
-
-actorGraphWithUserAttr &lt;-<span class="st"> </span>actorNetWithUserAttr<span class="op">$</span>graph <span class="co"># igraph network graph</span>
-
-semanticNetwork &lt;-<span class="st"> </span>twitterData <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"semantic"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)
-
-<span class="co"># -- Youtube Example --</span>
-
-<span class="co"># Authenticate with youtube, Collect comment data from videos and then Create an actor network</span>
-myYoutubeAPIKey &lt;-<span class="st"> "xxxxxxxxxxxxxx"</span>
-
-myYoutubeVideoIds &lt;-<span class="st"> </span><span class="kw"><a href="reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html">GetYoutubeVideoIDs</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"https://www.youtube.com/watch?v=xxxxxxxx"</span>,
-                                          <span class="st">"https://youtu.be/xxxxxxxx"</span>))
-                                 
-actorNetwork &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"youtube"</span>, <span class="dt">apiKey =</span> myYoutubeAPIKey) <span class="op">%&gt;%</span>
-<span class="st">                </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">videoIDs =</span> myYoutubeVideoIds) <span class="op">%&gt;%</span>
-<span class="st">                </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)
-
-<span class="co"># -- Reddit Example --</span>
-
-<span class="co"># Collect reddit comment threads and Create an actor network with comment text as edge attribute</span>
-myThreadUrls &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"https://www.reddit.com/r/xxxxxx/comments/xxxxxx/x_xxxx_xxxxxxxxx/"</span>)
-
-actorNetwork &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"reddit"</span>) <span class="op">%&gt;%</span>
-<span class="st">                </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">threadUrls =</span> myThreadUrls, <span class="dt">waitTime =</span> <span class="dv">5</span>) <span class="op">%&gt;%</span>
-<span class="st">                </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">includeTextData =</span> <span class="ot">TRUE</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)
-
-             
-<span class="co"># Optional save and load authentication objects from file using saveRDS, readRDS</span>
-
-<span class="co"># Save the object after Authenticate </span>
-<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/readRDS">saveRDS</a></span>(my_twitter_auth, <span class="dt">file =</span> <span class="st">"~/.twitter_auth"</span>)
-
-<span class="co"># Load a previously saved authentication object for use in Collect</span>
-my_twitter_auth &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/readRDS">readRDS</a></span>(<span class="st">"~/.twitter_auth"</span>)</code></pre></div>
+<div id="twitter-examples" class="section level4">
+<h4 class="hasAnchor">
+<a href="#twitter-examples" class="anchor"></a>Twitter Examples</h4>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" title="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)</a>
+<a class="sourceLine" id="cb4-2" title="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(vosonSML)</a>
+<a class="sourceLine" id="cb4-3" title="3"></a>
+<a class="sourceLine" id="cb4-4" title="4"><span class="co"># Authenticate with twitter, Collect 100 tweets for the '#auspol' hashtag and Create an actor and </span></a>
+<a class="sourceLine" id="cb4-5" title="5"><span class="co"># semantic network</span></a>
+<a class="sourceLine" id="cb4-6" title="6">myKeys &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">appName =</span> <span class="st">"vosonSML"</span>, <span class="dt">apiKey =</span> <span class="st">"xxxxxxxxxxxx"</span>, <span class="dt">apiSecret =</span> <span class="st">"xxxxxxxxxxxx"</span>, </a>
+<a class="sourceLine" id="cb4-7" title="7">               <span class="dt">accessToken =</span> <span class="st">"xxxxxxxxxxxx"</span>, <span class="dt">accessTokenSecret =</span> <span class="st">"xxxxxxxxxxxx"</span>)</a>
+<a class="sourceLine" id="cb4-8" title="8">  </a>
+<a class="sourceLine" id="cb4-9" title="9">twitterAuth &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"twitter"</span>, <span class="dt">appName =</span> myKeys<span class="op">$</span>appName, <span class="dt">apiKey =</span> myKeys<span class="op">$</span>apiKey, </a>
+<a class="sourceLine" id="cb4-10" title="10">                            <span class="dt">apiSecret =</span> myKeys<span class="op">$</span>apiSecret, <span class="dt">accessToken =</span> myKeys<span class="op">$</span>accessToken,</a>
+<a class="sourceLine" id="cb4-11" title="11">                            <span class="dt">accessTokenSecret =</span> myKeys<span class="op">$</span>accessTokenSecret)</a>
+<a class="sourceLine" id="cb4-12" title="12">                             </a>
+<a class="sourceLine" id="cb4-13" title="13">twitterData &lt;-<span class="st"> </span>twitterAuth <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb4-14" title="14"><span class="st">               </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">searchTerm =</span> <span class="st">"#auspol"</span>, <span class="dt">searchType =</span> <span class="st">"recent"</span>, <span class="dt">numTweets =</span> <span class="dv">100</span>, </a>
+<a class="sourceLine" id="cb4-15" title="15">                       <span class="dt">includeRetweets =</span> <span class="ot">FALSE</span>, <span class="dt">retryOnRateLimit =</span> <span class="ot">TRUE</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>, </a>
+<a class="sourceLine" id="cb4-16" title="16">                       <span class="dt">verbose =</span> <span class="ot">TRUE</span>)</a>
+<a class="sourceLine" id="cb4-17" title="17"></a>
+<a class="sourceLine" id="cb4-18" title="18">actorNetwork &lt;-<span class="st"> </span>twitterData <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>, <span class="dt">verbose =</span> <span class="ot">TRUE</span>)</a>
+<a class="sourceLine" id="cb4-19" title="19"></a>
+<a class="sourceLine" id="cb4-20" title="20">actorGraph &lt;-<span class="st"> </span>actorNetwork<span class="op">$</span>graph <span class="co"># igraph network graph</span></a>
+<a class="sourceLine" id="cb4-21" title="21"></a>
+<a class="sourceLine" id="cb4-22" title="22"><span class="co"># Optional step to add additional twitter user info to actor network graph as node attributes </span></a>
+<a class="sourceLine" id="cb4-23" title="23">actorNetWithUserAttr &lt;-<span class="st"> </span><span class="kw"><a href="reference/vosonSML-colon-colon-AddTwitterUserData.html">AddTwitterUserData</a></span>(twitterData, actorNetwork,</a>
+<a class="sourceLine" id="cb4-24" title="24">                                           <span class="dt">lookupUsers =</span> <span class="ot">TRUE</span>, </a>
+<a class="sourceLine" id="cb4-25" title="25">                                           <span class="dt">twitterAuth =</span> twitterAuth, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)</a>
+<a class="sourceLine" id="cb4-26" title="26"></a>
+<a class="sourceLine" id="cb4-27" title="27">actorGraphWithUserAttr &lt;-<span class="st"> </span>actorNetWithUserAttr<span class="op">$</span>graph <span class="co"># igraph network graph</span></a>
+<a class="sourceLine" id="cb4-28" title="28"></a>
+<a class="sourceLine" id="cb4-29" title="29">semanticNetwork &lt;-<span class="st"> </span>twitterData <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"semantic"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
+</div>
+<div id="youtube-examples" class="section level4">
+<h4 class="hasAnchor">
+<a href="#youtube-examples" class="anchor"></a>Youtube Examples</h4>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" title="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)</a>
+<a class="sourceLine" id="cb5-2" title="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(vosonSML)</a>
+<a class="sourceLine" id="cb5-3" title="3"></a>
+<a class="sourceLine" id="cb5-4" title="4"><span class="co"># Authenticate with youtube, Collect comment data from videos and then Create an actor network</span></a>
+<a class="sourceLine" id="cb5-5" title="5">myYoutubeAPIKey &lt;-<span class="st"> "xxxxxxxxxxxxxx"</span></a>
+<a class="sourceLine" id="cb5-6" title="6"></a>
+<a class="sourceLine" id="cb5-7" title="7">myYoutubeVideoIds &lt;-<span class="st"> </span><span class="kw"><a href="reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html">GetYoutubeVideoIDs</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"https://www.youtube.com/watch?v=xxxxxxxx"</span>,</a>
+<a class="sourceLine" id="cb5-8" title="8">                                          <span class="st">"https://youtu.be/xxxxxxxx"</span>))</a>
+<a class="sourceLine" id="cb5-9" title="9">                                 </a>
+<a class="sourceLine" id="cb5-10" title="10">actorNetwork &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"youtube"</span>, <span class="dt">apiKey =</span> myYoutubeAPIKey) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb5-11" title="11"><span class="st">                </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">videoIDs =</span> myYoutubeVideoIds) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb5-12" title="12"><span class="st">                </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
+</div>
+<div id="reddit-examples" class="section level4">
+<h4 class="hasAnchor">
+<a href="#reddit-examples" class="anchor"></a>Reddit Examples</h4>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" title="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)</a>
+<a class="sourceLine" id="cb6-2" title="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(vosonSML)</a>
+<a class="sourceLine" id="cb6-3" title="3"></a>
+<a class="sourceLine" id="cb6-4" title="4"><span class="co"># Collect reddit comment threads and Create an actor network with comment text as edge attribute</span></a>
+<a class="sourceLine" id="cb6-5" title="5">myThreadUrls &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"https://www.reddit.com/r/xxxxxx/comments/xxxxxx/x_xxxx_xxxxxxxxx/"</span>)</a>
+<a class="sourceLine" id="cb6-6" title="6"></a>
+<a class="sourceLine" id="cb6-7" title="7">actorNetwork &lt;-<span class="st"> </span><span class="kw"><a href="reference/Authenticate.html">Authenticate</a></span>(<span class="st">"reddit"</span>) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb6-8" title="8"><span class="st">                </span><span class="kw"><a href="reference/Collect.html">Collect</a></span>(<span class="dt">threadUrls =</span> myThreadUrls, <span class="dt">waitTime =</span> <span class="dv">5</span>) <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb6-9" title="9"><span class="st">                </span><span class="kw"><a href="reference/Create.html">Create</a></span>(<span class="st">"actor"</span>, <span class="dt">includeTextData =</span> <span class="ot">TRUE</span>, <span class="dt">writeToFile =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
+</div>
+<div id="save-and-load-authentication-objects" class="section level4">
+<h4 class="hasAnchor">
+<a href="#save-and-load-authentication-objects" class="anchor"></a>Save and Load Authentication Objects</h4>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" title="1"><span class="co"># Save the object after Authenticate </span></a>
+<a class="sourceLine" id="cb7-2" title="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/readRDS">saveRDS</a></span>(my_twitter_auth, <span class="dt">file =</span> <span class="st">"~/.twitter_auth"</span>)</a>
+<a class="sourceLine" id="cb7-3" title="3"></a>
+<a class="sourceLine" id="cb7-4" title="4"><span class="co"># Load a previously saved authentication object for use in Collect</span></a>
+<a class="sourceLine" id="cb7-5" title="5">my_twitter_auth &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/readRDS">readRDS</a></span>(<span class="st">"~/.twitter_auth"</span>)</a></code></pre></div>
 <p>For more detailed information and examples, please refer to the function <a href="https://vosonlab.github.io/vosonSML/reference/index.html">Reference</a> page.</p>
+</div>
 </div>
 </div>
 <div id="special-thanks" class="section level2">

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 
@@ -123,13 +123,33 @@
       <small>Source: <a href='https://github.com/vosonlab/vosonSML/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
-    <div id="vosonsml-0-27-0" class="section level1">
+    <div id="vosonsml-0271" class="section level1">
 <h1 class="page-header">
-<a href="#vosonsml-0-27-0" class="anchor"></a>vosonSML 0.27.0<small> Unreleased </small>
+<a href="#vosonsml-0271" class="anchor"></a>vosonSML 0.27.1<small> Unreleased </small>
 </h1>
 <div id="bug-fixes" class="section level2">
 <h2 class="hasAnchor">
 <a href="#bug-fixes" class="anchor"></a>Bug Fixes</h2>
+<ul>
+<li>Fixed a bug in <code>Create.semantic.twitter</code> in which a sum operation calculating edge weights would set <code>NA</code> values for all edges due to <code>NA</code> values present in the hashtag fields. This occurs when there are tweets with no hashtags in the twitter collection and is now checked.</li>
+<li>Some UTF encoding issues in <code>Create.semantic.twitter</code> were also fixed.</li>
+</ul>
+</div>
+<div id="minor-changes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#minor-changes" class="anchor"></a>Minor Changes</h2>
+<ul>
+<li>Added ‘#’ to hashtags and ‘@’ to mentions in twitter semantic network to differentiate between hashtags, mentions and common terms.</li>
+</ul>
+</div>
+</div>
+    <div id="vosonsml-0270" class="section level1">
+<h1 class="page-header">
+<a href="#vosonsml-0270" class="anchor"></a>vosonSML 0.27.0<small> Unreleased </small>
+</h1>
+<div id="bug-fixes-1" class="section level2">
+<h2 class="hasAnchor">
+<a href="#bug-fixes-1" class="anchor"></a>Bug Fixes</h2>
 <ul>
 <li>Fixed a bug in <code>Collect.twitter</code> in which any additional <code>twitter API</code> parameters e.g <code>lang</code> or <code>until</code> were not being passed properly to <code><a href="https://www.rdocumentation.org/packages/rtweet/topics/search_tweets">rtweet::search_tweets</a></code>. This resulted in the additional parameters being ignored.</li>
 </ul>
@@ -142,42 +162,42 @@
 <li>Changed the way that the <code>cleanText</code> parameter works in <code>Create.actor.reddit</code> so that it is more permissive. Addresses encoding issues with apostrophes and pound symbols and removes unicode characters not permitted by the XML 1.0 standard as used in <code>graphml</code> files. This is best effort and does not resolve all <code>reddit</code> text encoding issues.</li>
 </ul>
 </div>
-<div id="minor-changes" class="section level2">
+<div id="minor-changes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-1" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added <code>Collect.twitter</code> summary information that includes the earliest (min) and latest (max) tweet <code>status_id</code> collected with timestamp. The <code>status_id</code> values can be used to frame subsequent collections as <code>since_id</code> or <code>max_id</code> parameter values. If the <code>until</code> date parameter was used the timestamp can also be used as a quick confirmation.</li>
 <li>Added elapsed time output to the <code>Collect</code> method.</li>
 </ul>
 </div>
 </div>
-    <div id="vosonsml-0-26-3" class="section level1">
+    <div id="vosonsml-0263" class="section level1">
 <h1 class="page-header">
-<a href="#vosonsml-0-26-3" class="anchor"></a>vosonSML 0.26.3<small> 2019-02-22 </small>
+<a href="#vosonsml-0263" class="anchor"></a>vosonSML 0.26.3<small> 2019-02-22 </small>
 </h1>
-<div id="bug-fixes-1" class="section level2">
+<div id="bug-fixes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes-1" class="anchor"></a>Bug Fixes</h2>
+<a href="#bug-fixes-2" class="anchor"></a>Bug Fixes</h2>
 <ul>
 <li>Fixed bugs in <code>Create.actor.reddit</code> that were incorrectly creating edges between top-level commentors and thread authors from different threads. These bugs were only observable in when collecting multiple reddit threads.</li>
 </ul>
 </div>
-<div id="minor-changes-1" class="section level2">
+<div id="minor-changes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-1" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-2" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Improved output for <code>reddit</code> collection. Removed the progress bar and added a table of results summarising the number of comments collected for each thread.</li>
 <li>Added to <code>twitter</code> collection output the users <code>twitter API</code> reset time.</li>
 </ul>
 </div>
 </div>
-    <div id="vosonsml-0-26-2" class="section level1">
+    <div id="vosonsml-0262" class="section level1">
 <h1 class="page-header">
-<a href="#vosonsml-0-26-2" class="anchor"></a>vosonSML 0.26.2<small> Unreleased </small>
+<a href="#vosonsml-0262" class="anchor"></a>vosonSML 0.26.2<small> Unreleased </small>
 </h1>
-<div id="bug-fixes-2" class="section level2">
+<div id="bug-fixes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#bug-fixes-2" class="anchor"></a>Bug Fixes</h2>
+<a href="#bug-fixes-3" class="anchor"></a>Bug Fixes</h2>
 <ul>
 <li>Fixed a bug in <code>Create.actor.twitter</code> and <code>Create.bimodal.twitter</code> in which the vertices dataframe provided to the <code>graph_from_data_frame</code> function as a contained duplicate names raising an error.</li>
 </ul>
@@ -190,18 +210,18 @@
 <li>Updated all <code>Authenticate</code>, <code>Collect</code> and <code>Create</code> S3 methods to implement function routing based on object class names.</li>
 </ul>
 </div>
-<div id="minor-changes-2" class="section level2">
+<div id="minor-changes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-2" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-3" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Created a <code>pkgdown</code> web site for github hosted package documentation.</li>
 <li>Created a new hex sticker logo.</li>
 </ul>
 </div>
 </div>
-    <div id="vosonsml-0-25-0" class="section level1">
+    <div id="vosonsml-0250" class="section level1">
 <h1 class="page-header">
-<a href="#vosonsml-0-25-0" class="anchor"></a>vosonSML 0.25.0<small> Unreleased </small>
+<a href="#vosonsml-0250" class="anchor"></a>vosonSML 0.25.0<small> Unreleased </small>
 </h1>
 <div id="major-changes-2" class="section level2">
 <h2 class="hasAnchor">
@@ -218,10 +238,11 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
-        <li><a href="#vosonsml-0-27-0">0.27.0</a></li>
-        <li><a href="#vosonsml-0-26-3">0.26.3</a></li>
-        <li><a href="#vosonsml-0-26-2">0.26.2</a></li>
-        <li><a href="#vosonsml-0-25-0">0.25.0</a></li>
+        <li><a href="#vosonsml-0271">0.27.1</a></li>
+        <li><a href="#vosonsml-0270">0.27.0</a></li>
+        <li><a href="#vosonsml-0263">0.26.3</a></li>
+        <li><a href="#vosonsml-0262">0.26.2</a></li>
+        <li><a href="#vosonsml-0250">0.25.0</a></li>
       </ul>
     </div>
   </div>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,4 +1,4 @@
-pandoc: 1.19.2.1
+pandoc: '2.6'
 pkgdown: 1.3.0
 pkgdown_sha: ~
 articles: []

--- a/docs/reference/Authenticate.html
+++ b/docs/reference/Authenticate.html
@@ -79,7 +79,7 @@ Authenticate.reddit for parameters and usage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.reddit.html
+++ b/docs/reference/Authenticate.reddit.html
@@ -74,7 +74,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.twitter.html
+++ b/docs/reference/Authenticate.twitter.html
@@ -75,7 +75,7 @@ https://developer.twitter.com/en/docs/basics/authentication/overview/oauth." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.youtube.html
+++ b/docs/reference/Authenticate.youtube.html
@@ -75,7 +75,7 @@ https://developers.google.com/youtube/v3/docs/." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.html
+++ b/docs/reference/Collect.html
@@ -78,7 +78,7 @@ Collect.reddit for parameters and usage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.reddit.html
+++ b/docs/reference/Collect.reddit.html
@@ -75,7 +75,7 @@ the data into a dataframe with the class names &quot;datasource&quot; and &quot;
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.twitter.html
+++ b/docs/reference/Collect.twitter.html
@@ -86,7 +86,7 @@ documentation for query operators: https://developer.twitter.com/en/docs/tweets/
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.youtube.html
+++ b/docs/reference/Collect.youtube.html
@@ -83,7 +83,7 @@ https://developers.google.com/youtube/v3/getting-started" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.reddit.html
+++ b/docs/reference/Create.actor.reddit.html
@@ -76,7 +76,7 @@ weights (weight) or edge text attributes (vosonTxt_comment) can be created." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.twitter.html
+++ b/docs/reference/Create.actor.twitter.html
@@ -77,7 +77,7 @@ without relations to other users will appear in the network graph as isolate nod
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.youtube.html
+++ b/docs/reference/Create.actor.youtube.html
@@ -77,7 +77,7 @@ the videos publisher with top-level comments as directed edges towards them." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.bimodal.twitter.html
+++ b/docs/reference/Create.bimodal.twitter.html
@@ -77,7 +77,7 @@ the name of the node they are directed towards." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.html
+++ b/docs/reference/Create.html
@@ -81,7 +81,7 @@ Create.semantic.twitter functions for parameters and usage respectively." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/Create.semantic.twitter.html
+++ b/docs/reference/Create.semantic.twitter.html
@@ -77,7 +77,7 @@ weighted and represent usage of frequently occurring terms and hashtags by the a
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddTwitterUserData.html
+++ b/docs/reference/vosonSML-colon-colon-AddTwitterUserData.html
@@ -75,7 +75,7 @@ additional downloaded twitter user information applied as node attributes." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html
+++ b/docs/reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html
@@ -77,7 +77,7 @@ parameter." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-ImportData.html
+++ b/docs/reference/vosonSML-colon-colon-ImportData.html
@@ -75,7 +75,7 @@ socialmedia type that is usable by Create functions." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-package.html
+++ b/docs/reference/vosonSML-package.html
@@ -86,7 +86,7 @@ the Create function resulting in a twitter network (as igraph object) that is re
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.27.1</span>
       </span>
     </div>
 

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -11,7 +11,7 @@ h3, .h3 {
 } 
 
 h4, .h4, h5, .h5 {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
 }
 
 .contents h1, .contents h2 {


### PR DESCRIPTION
Bug Fixes:
- Fixed a bug in `Create.semantic.twitter` in which a sum operation calculating edge weights would set `NA` values for all edges due to `NA` values present in the hashtag fields. This occurs when there are tweets with no hashtags in the twitter collection and is now checked.
- Some UTF encoding issues in `Create.semantic.twitter` were also fixed.
  
Minor Changes:
- Added '#' to hashtags and '@' to mentions in twitter semantic network to differentiate between hashtags, mentions and common terms.