### PR TITLE
Minor documentation updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vosonSML
-Version: 0.29.12
+Version: 0.29.13
 Title: Collecting Social Media Data and Generating Networks for Analysis
 Description: A suite of tools for collecting and constructing networks from social media data.
     Provides easy-to-use functions for collecting data across popular platforms (Twitter, YouTube

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# vosonSML 0.29.13
+
+## Minor Changes
+- Minor documentation updates to `Create.semantic.twitter`, `Create.twomode.twitter` and the `Intro-to-vosonSML` vignette:
+    - Specified the `tidyr` and `tidytext` package requirements in descriptions and examples
+    - Updated references to `twomode` networks as `2-mode` where possible
+
 # vosonSML 0.29.12
 
 ## Bug Fixes

--- a/R/Create.R
+++ b/R/Create.R
@@ -97,7 +97,7 @@ Create.semantic.default <- function(datasource, type, ...) {
   stop("Unknown datasource passed to create semantic network.", call. = FALSE) 
 }
 
-#' @title Create twomode networks from social media data
+#' @title Create 2-mode networks from social media data
 #'
 #' @noRd
 #' @method Create twomode

--- a/R/Create.semantic.twitter.R
+++ b/R/Create.semantic.twitter.R
@@ -2,14 +2,18 @@
 #' 
 #' @description Creates a semantic network from tweets returned from the twitter search query. Semantic networks 
 #' describe the semantic relationships between concepts. In this network the concepts are significant words and 
-#' hashtags extracted from the tweet text. Network edges are weighted and represent occurence of words and
+#' hashtags extracted from the tweet text. Network edges are weighted and represent occurrence of words and
 #' hashtags in the same tweets.
+#' 
+#' The creation of twitter semantic networks requires text processing and the tokenization of tweets. As such
+#' this function requires the additional installation of the \pkg{tidyr} and \pkg{tidytext} packages to achieve
+#' this.
 #' 
 #' @note The words and hashtags passed to the function in the \code{removeTermsOrHashtags} parameter are removed
 #' before word frequencies are calculated and are therefore excluded from top percentage of most frequent terms
 #' completely rather than simply filtered out of the final network.
 #' 
-#' The top percentage of frequently occuring hashtags \code{hashtagFreq} and words \code{termFreq} are calculated to a
+#' The top percentage of frequently occurring hashtags \code{hashtagFreq} and words \code{termFreq} are calculated to a
 #' minimum frequency and all terms that have an equal or greater frequency than the minimum are included in the network
 #' as nodes. For example, of unique hashtags of varying frequencies in a dataset the top 50% of total
 #' frequency or most common hashtags may calculate to being the first 20 hashtags. The frequency of the 20th hashtag is
@@ -51,6 +55,10 @@
 #' 
 #' @examples
 #' \dontrun{
+#' # twitter semantic network creation additionally requires the tidyr and tidytext packages
+#' # for working with text data
+#' install.packages(c("tidytext", "tidyr"))
+#' 
 #' # create a twitter semantic network graph removing the hashtag '#auspol' and using the
 #' # top 2% frequently occurring words and 10% most frequently occurring hashtags as nodes
 #' semanticNetwork <- twitterData %>% 

--- a/R/Create.twomode.twitter.R
+++ b/R/Create.twomode.twitter.R
@@ -1,9 +1,12 @@
-#' @title Create twitter twomode network
+#' @title Create twitter 2-mode network
 #' 
-#' @description Creates a twomode network from tweets returned from the twitter search query. In this network there are 
+#' @description Creates a 2-mode network from tweets returned from the twitter search query. In this network there are 
 #' two types of nodes, twitter users who authored or were mentioned in collected tweets and hashtags found within
 #' tweets. Network edges represent a users tweets that contain hashtags or mention users screen names.
 #'
+#' The creation of twitter 2-mode networks requires text processing and the tokenization of tweets. As such
+#' this function requires the additional installation of the \pkg{tidytext} package to achieve this.
+#' 
 #' @param datasource Collected social media data with \code{"datasource"} and \code{"twitter"} class names.
 #' @param type Character string. Type of network to be created, set to \code{"twomode"}.
 #' @param removeTermsOrHashtags Character vector. Users or hashtags to remove from the twomode network. For example, 
@@ -18,7 +21,11 @@
 #' 
 #' @examples
 #' \dontrun{
-#' # create a twitter twomode network graph removing the hashtag '#auspol' as it was used in 
+#' # twitter 2-mode network creation additionally requires the tidytext package
+#' # for working with text data
+#' install.packages("tidytext")
+#' 
+#' # create a twitter 2-mode network graph removing the hashtag '#auspol' as it was used in 
 #' # the twitter search query
 #' twomodeNetwork <- twitterData %>% 
 #'                   Create("twomode", removeTermsOrHashtags = c("#auspol"), verbose = TRUE)
@@ -31,7 +38,7 @@
 #' @export
 Create.twomode.twitter <- function(datasource, type, removeTermsOrHashtags = NULL, weighted = TRUE, 
                                    verbose = FALSE, ...) {
-  cat("Generating twitter twomode network...")
+  cat("Generating twitter 2-mode network...")
   if (verbose) { cat("\n") }
 
   if (!requireNamespace("tidytext", quietly = TRUE)) {

--- a/R/Graph.R
+++ b/R/Graph.R
@@ -188,7 +188,7 @@ Graph.twomode.twitter <- function(net, directed = TRUE, writeToFile = FALSE, ...
   
   g <- set_graph_attr(g, "type", "twitter")
   
-  graphOutputFile(g, "graphml", writeToFile, "TwitterTwomode")
+  graphOutputFile(g, "graphml", writeToFile, "Twitter2mode")
   cat("Done.\n")
   
   g  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Downloads](https://cranlogs.r-pkg.org/badges/vosonSML)](https://CRAN.R-project.org/package=vosonSML)
 [![Total](https://cranlogs.r-pkg.org/badges/grand-total/vosonSML)](https://CRAN.R-project.org/package=vosonSML)
 [![Github Release](https://img.shields.io/github/release-pre/vosonlab/vosonSML.svg?logo=github&colorB=8065ac)](https://github.com/vosonlab/vosonSML/releases)
-[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.29.12&color=659DBD&logo=github)](https://github.com/vosonlab/vosonSML)
+[![Dev](https://img.shields.io/static/v1?label=dev&message=v0.29.13&color=659DBD&logo=github)](https://github.com/vosonlab/vosonSML)
 [![Last Commit](https://img.shields.io/github/last-commit/vosonlab/vosonSML.svg?&color=659DBD&logo=github)](https://github.com/vosonlab/vosonSML/commits/master)
 
 `vosonSML` is an R package that provides a suite of tools for collecting and constructing networks from social media data. It provides easy-to-use functions for collecting data across popular platforms and generating different types of networks for analysis.
@@ -29,7 +29,7 @@ install.packages("https://github.com/vosonlab/vosonSML/releases/download/v0.29.1
   repo = NULL, type = "source")
 ```
 
-Install the latest development version (v0.29.12):
+Install the latest development version (v0.29.13):
 ``` r
 # library(devtools)
 devtools::install_github("vosonlab/vosonSML")
@@ -102,7 +102,7 @@ twitterData <- twitterAuth %>%
 #> Done.
 ```
 
-#### 'Create' twitter 'activity', 'actor', 'semantic' and 'twomode' network graphs
+#### 'Create' twitter 'activity', 'actor', 'semantic' and '2-mode' network graphs
 
 The twitter `Create` function accepts the data from `Collect` and a type parameter of `activity`, `actor`, `semantic` or `twomode` that specifies the type of network to create from the collected data. `Create` produces two dataframes, one for network `nodes` and one for node relations or `edges` in the network. These can then undergo further processing as per the [supplemental functions](#supplemental-functions) section or be passed to the `Graph` function that creates an `igraph` object.
 
@@ -206,10 +206,12 @@ semanticNetwork <- twitterData %>%
 #> + attr: type (g/c), name (v/c), n (v/n), type (v/c), label (v/c), weight (e/n)
 ```
 
-##### Twomode network
+##### 2-mode network
 
 Nodes are twitter users and hashtags, edges represent the use of a hashtag or the reference to another user in a tweet.
 ``` r
+install.packages("tidytext") # install additional required packages
+
 twomodeNetwork <- twitterData %>%
   Create("twomode", 
          removeTermsOrHashtags = c("#auspol"),
@@ -219,7 +221,7 @@ twomodeNetwork <- twitterData %>%
   summary()
 ```
 ``` r
-#> Generating twitter twomode network...
+#> Generating twitter 2-mode network...
 #> Removing terms and hashtags: #auspol
 #> -------------------------
 #> collected tweets  | 100
@@ -231,7 +233,7 @@ twomodeNetwork <- twitterData %>%
 #> -------------------------
 #> Done.
 #> Creating igraph network graph...
-#> GRAPHML file written: D:/wd/2020-04-20_003907-TwitterTwomode.graphml
+#> GRAPHML file written: D:/wd/2020-04-20_003907-Twitter2mode.graphml
 #> Done.
 #> IGRAPH 86847fb DNW- 176 166 -- 
 #> + attr: type (g/c), name (v/c), user_id (v/c), label (v/c), weight (e/n)

--- a/docs/404.html
+++ b/docs/404.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="http://vosonlab.github.io/vosonSML/index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/articles/Intro-to-vosonSML.html
+++ b/docs/articles/Intro-to-vosonSML.html
@@ -38,7 +38,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -115,7 +115,7 @@
             <h3 class="subtitle">VOSON Lab, Australian National University</h3>
                         <h4 class="author">Robert Ackland, Bryan Gertzel, Francisca Borquez</h4>
             
-            <h4 class="date">14 June, 2020</h4>
+            <h4 class="date">18 June, 2020</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/vosonlab/vosonSML/blob/master/vignettes/Intro-to-vosonSML.Rmd"><code>vignettes/Intro-to-vosonSML.Rmd</code></a></small>
       <div class="hidden name"><code>Intro-to-vosonSML.Rmd</code></div>
@@ -191,7 +191,7 @@
 <div id="creating-twitter-networks" class="section level2">
 <h2 class="hasAnchor">
 <a href="#creating-twitter-networks" class="anchor"></a>Creating Twitter Networks</h2>
-<p>It is currently possible to create four types of networks using Twitter data: (1) <em>actor network</em>; (2) <em>activity network</em>; (3) <em>two-mode network</em> and (4) <em>semantic network</em>.</p>
+<p>It is currently possible to create four types of networks using Twitter data: (1) <em>actor network</em>; (2) <em>activity network</em>; (3) <em>2-mode network</em> and (4) <em>semantic network</em>.</p>
 <div id="actor-network" class="section level3">
 <h3 class="hasAnchor">
 <a href="#actor-network" class="anchor"></a>Actor Network</h3>
@@ -323,10 +323,10 @@ IGRAPH e60c486 DN-- 1408 662 --
 </div>
 <p>It should be noted that a limitation of the Twitter API is that retweet chains are not provided. That is: if user <em>i</em> tweeted an original tweet, and then user <em>j</em> retweeted this tweet, and user <em>k</em> retweeted <em>j</em>’s retweet, the activity network will show edges connecting the two retweets to the original tweet.</p>
 </div>
-<div id="two-mode-network" class="section level3">
+<div id="mode-network" class="section level3">
 <h3 class="hasAnchor">
-<a href="#two-mode-network" class="anchor"></a>Two-mode Network</h3>
-<p>In the Twitter <em>two-mode network</em>, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user <em>i</em> to hashtag <em>j</em> if user <em>i</em> authored a tweet containing hashtag <em>j</em>.</p>
+<a href="#mode-network" class="anchor"></a>2-mode Network</h3>
+<p>In the Twitter <em>2-mode network</em>, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user <em>i</em> to hashtag <em>j</em> if user <em>i</em> authored a tweet containing hashtag <em>j</em>.</p>
 <div class="sourceCode" id="cb22"><html><body><pre class="r"><span class="no">twomodeNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/Create.html">Create</a></span>(<span class="st">"twomode"</span>, <span class="kw">removeTermsOrHashtags</span> <span class="kw">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"#auspol"</span>))
 <span class="no">twomodeGraph</span> <span class="kw">&lt;-</span> <span class="no">twomodeNetwork</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/vosonSML-colon-colon-Graph.html">Graph</a></span>(<span class="kw">writeToFile</span> <span class="kw">=</span> <span class="fl">TRUE</span>)</pre></body></html></div>
 <p><code><a href="../reference/Create.html">Create("twomode")</a></code> returns a named list containing two dataframes named “nodes” and “edges” (the following has been modified to preserve anonymity). Note that in this example, the <code>removeTermsOrHashtags</code> argument was used to exclude ‘#auspol’, since by construction all tweets contained this hashtag.</p>
@@ -363,7 +363,7 @@ IGRAPH 68bd240 DN-- 1146 1675 --
  [2] xxxx -&gt; #australianbushfiredisaster 
 [snip]
 + ... omitted several edges</pre></body></html></div>
-<p>The Twitter two-model network has a graph attribute <code>type</code> (set to “twitter”). The node attributes are: <code>name</code> (hashtag or Twitter user ID), <code>display_name</code> (hashtag or Twitter handle or screen name), <code>label</code> (for users, a concatenation of <code>name</code> and <code>display_name</code>, while for hashtags it is <code>name</code>). The edge attributes are: <code>edge_type</code> (‘hashtag’), <code>timestamp</code> (timestamp of the tweet that led to the edge), <code>status_id</code> (Twitter ID of the tweet that led to the edge).</p>
+<p>The Twitter 2-model network has a graph attribute <code>type</code> (set to “twitter”). The node attributes are: <code>name</code> (hashtag or Twitter user ID), <code>display_name</code> (hashtag or Twitter handle or screen name), <code>label</code> (for users, a concatenation of <code>name</code> and <code>display_name</code>, while for hashtags it is <code>name</code>). The edge attributes are: <code>edge_type</code> (‘hashtag’), <code>timestamp</code> (timestamp of the tweet that led to the edge), <code>status_id</code> (Twitter ID of the tweet that led to the edge).</p>
 <div class="sourceCode" id="cb25"><html><body><pre class="r"><span class="no">ind</span> <span class="kw">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/order.html">order</a></span>(<span class="fu"><a href="https://rdrr.io/pkg/igraph/man/degree.html">degree</a></span>(<span class="no">twomodeGraph</span>, <span class="kw">mode</span><span class="kw">=</span><span class="st">"in"</span>), <span class="kw">decreasing</span><span class="kw">=</span><span class="fl">TRUE</span>)[<span class="fl">1</span>:<span class="fl">5</span>] <span class="co"># top-5 hashtags</span>
 <span class="co"># users who tweet with these hashtags</span>
 <span class="no">ind2</span> <span class="kw">&lt;-</span> <span class="fu"><a href="https://rdrr.io/r/base/unlist.html">unlist</a></span>(<span class="fu"><a href="https://rdrr.io/r/base/lapply.html">lapply</a></span>(<span class="no">ind</span>, <span class="kw">function</span>(<span class="no">x</span>){<span class="fu"><a href="https://rdrr.io/pkg/igraph/man/neighbors.html">neighbors</a></span>(<span class="no">twomodeGraph</span>, <span class="no">x</span>, <span class="kw">mode</span><span class="kw">=</span><span class="st">"in"</span>)}))
@@ -376,7 +376,7 @@ IGRAPH 68bd240 DN-- 1146 1675 --
      <span class="kw">vertex.label.color</span><span class="kw">=</span><span class="st">"red"</span>)
 <span class="fu"><a href="https://rdrr.io/r/grDevices/dev.html">dev.off</a></span>()</pre></body></html></div>
 <div class="figure">
-<img src="https://vosonlab.github.io/vosonSML/images/intro-to-vosonsml/twitter_twomode.png" alt=""><p class="caption">Twitter twomode network - top-5 hashtags, and the users who tweeted them</p>
+<img src="https://vosonlab.github.io/vosonSML/images/intro-to-vosonsml/twitter_twomode.png" alt=""><p class="caption">Twitter 2-mode network - top-5 hashtags, and the users who tweeted them</p>
 </div>
 </div>
 <div id="semantic-network" class="section level3">

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,7 +40,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -133,7 +133,7 @@
 <p>Install the latest release via GitHub (v0.29.12):</p>
 <div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/vosonSML/releases/download/v0.29.12/vosonSML-0.29.12.tar.gz"</span>,
   <span class="kw">repo</span> <span class="kw">=</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="kw">=</span> <span class="st">"source"</span>)</pre></div>
-<p>Install the latest development version (v0.29.12):</p>
+<p>Install the latest development version (v0.29.13):</p>
 <div class="sourceCode" id="cb3"><pre class="r"><span class="co"># library(devtools)</span>
 <span class="kw pkg">devtools</span><span class="kw ns">::</span><span class="fu">install_github</span>(<span class="st">"vosonlab/vosonSML"</span>)</pre></div>
 </div>
@@ -199,9 +199,9 @@
 #&gt; Collected 100 tweets.
 #&gt; Done.</pre></div>
 </div>
-<div id="create-twitter-activity-actor-semantic-and-twomode-network-graphs" class="section level4">
+<div id="create-twitter-activity-actor-semantic-and-2-mode-network-graphs" class="section level4">
 <h4 class="hasAnchor">
-<a href="#create-twitter-activity-actor-semantic-and-twomode-network-graphs" class="anchor"></a>‘Create’ twitter ‘activity’, ‘actor’, ‘semantic’ and ‘twomode’ network graphs</h4>
+<a href="#create-twitter-activity-actor-semantic-and-2-mode-network-graphs" class="anchor"></a>‘Create’ twitter ‘activity’, ‘actor’, ‘semantic’ and ‘2-mode’ network graphs</h4>
 <p>The twitter <code>Create</code> function accepts the data from <code>Collect</code> and a type parameter of <code>activity</code>, <code>actor</code>, <code>semantic</code> or <code>twomode</code> that specifies the type of network to create from the collected data. <code>Create</code> produces two dataframes, one for network <code>nodes</code> and one for node relations or <code>edges</code> in the network. These can then undergo further processing as per the <a href="#supplemental-functions">supplemental functions</a> section or be passed to the <code>Graph</code> function that creates an <code>igraph</code> object.</p>
 <div id="activity-network" class="section level5">
 <h5 class="hasAnchor">
@@ -294,18 +294,20 @@
 #&gt; IGRAPH ae1da92 UNWB 199 95 -- 
 #&gt; + attr: type (g/c), name (v/c), n (v/n), type (v/c), label (v/c), weight (e/n)</pre></div>
 </div>
-<div id="twomode-network" class="section level5">
+<div id="2-mode-network" class="section level5">
 <h5 class="hasAnchor">
-<a href="#twomode-network" class="anchor"></a>Twomode network</h5>
+<a href="#2-mode-network" class="anchor"></a>2-mode network</h5>
 <p>Nodes are twitter users and hashtags, edges represent the use of a hashtag or the reference to another user in a tweet.</p>
-<div class="sourceCode" id="cb14"><pre class="r"><span class="no">twomodeNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span>
+<div class="sourceCode" id="cb14"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"tidytext"</span>) <span class="co"># install additional required packages</span>
+
+<span class="no">twomodeNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span>
   <span class="fu"><a href="reference/Create.html">Create</a></span>(<span class="st">"twomode"</span>,
          <span class="kw">removeTermsOrHashtags</span> <span class="kw">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"#auspol"</span>),
          <span class="kw">weighted</span> <span class="kw">=</span> <span class="fl">TRUE</span>,
          <span class="kw">verbose</span> <span class="kw">=</span> <span class="fl">TRUE</span>) <span class="kw">%&gt;%</span>
   <span class="fu"><a href="reference/vosonSML-colon-colon-Graph.html">Graph</a></span>() <span class="kw">%&gt;%</span>
   <span class="fu"><a href="https://rdrr.io/r/base/summary.html">summary</a></span>()</pre></div>
-<div class="sourceCode" id="cb15"><pre class="r">#&gt; Generating twitter twomode network...
+<div class="sourceCode" id="cb15"><pre class="r">#&gt; Generating twitter 2-mode network...
 #&gt; Removing terms and hashtags: #auspol
 #&gt; -------------------------
 #&gt; collected tweets  | 100
@@ -317,7 +319,7 @@
 #&gt; -------------------------
 #&gt; Done.
 #&gt; Creating igraph network graph...
-#&gt; GRAPHML file written: D:/wd/2020-04-20_003907-TwitterTwomode.graphml
+#&gt; GRAPHML file written: D:/wd/2020-04-20_003907-Twitter2mode.graphml
 #&gt; Done.
 #&gt; IGRAPH 86847fb DNW- 176 166 -- 
 #&gt; + attr: type (g/c), name (v/c), user_id (v/c), label (v/c), weight (e/n)</pre></div>
@@ -616,7 +618,7 @@ actorNetwork &lt;- actorNetwork %&gt;%
 <li><a href="https://CRAN.R-project.org/package=vosonSML"><img src="https://cranlogs.r-pkg.org/badges/vosonSML" alt="Downloads"></a></li>
 <li><a href="https://CRAN.R-project.org/package=vosonSML"><img src="https://cranlogs.r-pkg.org/badges/grand-total/vosonSML" alt="Total"></a></li>
 <li><a href="https://github.com/vosonlab/vosonSML/releases"><img src="https://img.shields.io/github/release-pre/vosonlab/vosonSML.svg?logo=github&amp;colorB=8065ac" alt="Github Release"></a></li>
-<li><a href="https://github.com/vosonlab/vosonSML"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.29.12&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
+<li><a href="https://github.com/vosonlab/vosonSML"><img src="https://img.shields.io/static/v1?label=dev&amp;message=v0.29.13&amp;color=659DBD&amp;logo=github" alt="Dev"></a></li>
 <li><a href="https://github.com/vosonlab/vosonSML/commits/master"><img src="https://img.shields.io/github/last-commit/vosonlab/vosonSML.svg?&amp;color=659DBD&amp;logo=github" alt="Last Commit"></a></li>
 </ul>
 </div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -157,6 +157,23 @@
       <small>Source: <a href='https://github.com/vosonlab/vosonSML/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="vosonsml-02913" class="section level1">
+<h1 class="page-header" data-toc-text="0.29.13">
+<a href="#vosonsml-02913" class="anchor"></a>vosonSML 0.29.13<small> Unreleased </small>
+</h1>
+<div id="minor-changes" class="section level2">
+<h2 class="hasAnchor">
+<a href="#minor-changes" class="anchor"></a>Minor Changes</h2>
+<ul>
+<li>Minor documentation updates to <code>Create.semantic.twitter</code>, <code>Create.twomode.twitter</code> and the <code>Intro-to-vosonSML</code> vignette:
+<ul>
+<li>Specified the <code>tidyr</code> and <code>tidytext</code> package requirements in descriptions and examples</li>
+<li>Updated references to <code>twomode</code> networks as <code>2-mode</code> where possible</li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
     <div id="vosonsml-02912" class="section level1">
 <h1 class="page-header" data-toc-text="0.29.12">
 <a href="#vosonsml-02912" class="anchor"></a>vosonSML 0.29.12<small> Unreleased </small>
@@ -169,9 +186,9 @@
 <li>Replaced an instance of the deprecated <code><a href="https://dplyr.tidyverse.org/reference/funs.html">dplyr::funs</a></code> function that was generating a warning.</li>
 </ul>
 </div>
-<div id="minor-changes" class="section level2">
+<div id="minor-changes-1" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-1" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Minor documentation updates.</li>
 </ul>
@@ -193,9 +210,9 @@
 <h1 class="page-header" data-toc-text="0.29.10">
 <a href="#vosonsml-02910" class="anchor"></a>vosonSML 0.29.10<small> 2020-04-25 </small>
 </h1>
-<div id="minor-changes-1" class="section level2">
+<div id="minor-changes-2" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-1" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-2" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Reimplemented the <code>Create.semantic.twitter</code> and <code>Create.twomode.twitter</code> functions using the <code>tidytext</code> package. They now better support tokenization of tweet text and allows a range of stopword lists and sources to be used from the <code>stopwords</code> package. The semantic network function requires the <code>tidytext</code> and <code>tidyr</code> packages to be installed before use.</li>
 <li>New parameters have been added to <code>Create.semantic.twitter</code>:
@@ -216,9 +233,9 @@
 <h1 class="page-header" data-toc-text="0.29.9">
 <a href="#vosonsml-0299" class="anchor"></a>vosonSML 0.29.9<small> Unreleased </small>
 </h1>
-<div id="minor-changes-2" class="section level2">
+<div id="minor-changes-3" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-2" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-3" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Updated <code>Introduction to vosonSML</code> vignette <code>Merging Collected Data</code> examples.</li>
 <li>Added new hex sticker to package documentation.</li>
@@ -243,9 +260,9 @@
 <li>A recent intermittent problem with the Twitter API caused an issue with the <code><a href="https://rdrr.io/pkg/rtweet/man/rate_limit.html">rtweet::rate_limit</a></code> function that resulted in an error when using the rtweet <code>retryonratelimit</code> search parameter. The <code>rate_limit</code> function was being called by <code>vosonSML</code> to check the twitter rate limit regardless of whether the search parameter was set or not, and so was failing <code>Collect</code> with an error. A fix was made so that <code>vosonSML</code> checks if <code><a href="https://rdrr.io/pkg/rtweet/man/rate_limit.html">rtweet::rate_limit</a></code> succeeds, and if not automatically sets <code>retryonratelimit</code> to <code>FALSE</code> so that a twitter <code>Collect</code> can still be performed without error should this problem occur again.</li>
 </ul>
 </div>
-<div id="minor-changes-3" class="section level2">
+<div id="minor-changes-4" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-3" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-4" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added some links to the <code>pkgdown</code> site navbar.</li>
 </ul>
@@ -255,9 +272,9 @@
 <h1 class="page-header" data-toc-text="0.29.7">
 <a href="#vosonsml-0297" class="anchor"></a>vosonSML 0.29.7<small> Unreleased </small>
 </h1>
-<div id="minor-changes-4" class="section level2">
+<div id="minor-changes-5" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-4" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-5" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added some guidance for merging collected data to the <code>Introduction to vosonSML</code> vignette.</li>
 </ul>
@@ -267,9 +284,9 @@
 <h1 class="page-header" data-toc-text="0.29.6">
 <a href="#vosonsml-0296" class="anchor"></a>vosonSML 0.29.6<small> Unreleased </small>
 </h1>
-<div id="minor-changes-5" class="section level2">
+<div id="minor-changes-6" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-5" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-6" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added <code>Introduction to vosonSML</code> vignette to the package.</li>
 <li>Minor changes and input checks added to <code>ImportData</code>.</li>
@@ -281,9 +298,9 @@
 <h1 class="page-header" data-toc-text="0.29.5">
 <a href="#vosonsml-0295" class="anchor"></a>vosonSML 0.29.5<small> Unreleased </small>
 </h1>
-<div id="minor-changes-6" class="section level2">
+<div id="minor-changes-7" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-6" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-7" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Reddit JSON is now retrieved using <code><a href="https://jeroen.cran.dev/jsonlite/reference/fromJSON.html">jsonlite::fromJSON</a></code>.</li>
 <li>Reddit ‘Continue’ threads are now followed with additional thread requests. Many more comments are now collected for threads with large diameters or breadth. Continue threads also have a Reddit limit of 500 comments per thread request.</li>
@@ -300,9 +317,9 @@
 <h1 class="page-header" data-toc-text="0.29.4">
 <a href="#vosonsml-0294" class="anchor"></a>vosonSML 0.29.4<small> 2019-11-23 </small>
 </h1>
-<div id="minor-changes-7" class="section level2">
+<div id="minor-changes-8" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-7" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-8" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Renamed <code>bimodal</code> networks to <code>twomode</code>.</li>
 </ul>
@@ -312,9 +329,9 @@
 <h1 class="page-header" data-toc-text="0.29.3">
 <a href="#vosonsml-0293" class="anchor"></a>vosonSML 0.29.3<small> Unreleased </small>
 </h1>
-<div id="minor-changes-8" class="section level2">
+<div id="minor-changes-9" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-8" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-9" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added output messages from supplemental functions such as <code><a href="../reference/vosonSML-colon-colon-AddText.html">AddText()</a></code> and <code><a href="../reference/vosonSML-colon-colon-Graph.html">Graph()</a></code>. Also improved consistency of output messages from <code>Collect</code> and <code>Create</code> functions.</li>
 </ul>
@@ -335,9 +352,9 @@
 <h1 class="page-header" data-toc-text="0.29.2">
 <a href="#vosonsml-0292" class="anchor"></a>vosonSML 0.29.2<small> Unreleased </small>
 </h1>
-<div id="minor-changes-9" class="section level2">
+<div id="minor-changes-10" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-9" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-10" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>A feature was added to the youtube actor <code>AddText</code> function to redirect edges towards actors based on the presence of a <code>screen name</code> or <code>@screen name</code> that may be found at the beginning of a reply comment. Typically reply comments are directed towards a top-level comment, this instead captures when reply comments are directed to other commenters in the thread.</li>
 </ul>
@@ -347,9 +364,9 @@
 <h1 class="page-header" data-toc-text="0.29.1">
 <a href="#vosonsml-0291" class="anchor"></a>vosonSML 0.29.1<small> Unreleased </small>
 </h1>
-<div id="minor-changes-10" class="section level2">
+<div id="minor-changes-11" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-10" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-11" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Changed youtube <code>actor</code> network identifiers to be their unique <code>Channel ID</code> instead of their <code>screen names</code>.</li>
 <li>Created the <code>AddVideoData</code> function to add collected video data to the youtube <code>actor</code> network. The main purpose of this function is to replace video identifiers with the <code>Channel ID</code> of the video publisher (actor) instead. To get the <code>Channel ID</code> of video publishers an additional API lookup for the videos in the network is required. Additional columns such as video <code>Title</code>, <code>Description</code> and <code>Published</code> time are also added to the network <code>$edges</code> dataframe as well as returned in their own dataframe called <code>$videos</code>.</li>
@@ -368,9 +385,9 @@
 <li>Generation of <code>igraph</code> graph objects and subsequent writing to file has been removed from the <code>Create</code> function and placed in a new function <code>Graph</code>. This change abstracts the graph creation and makes it optional, but also allows supplemental network steps such as <code>AddText</code> to be performed prior to creating the final igraph object.</li>
 </ul>
 </div>
-<div id="minor-changes-11" class="section level2">
+<div id="minor-changes-12" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-11" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-12" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Removed <code>writeToFile</code> parameter from <code>Create</code> functions and added it to <code>Graph</code>.</li>
 <li>Removed <code>weightEdges</code>, <code>textData</code> and <code>cleanText</code> parameters from <code>Create.actor.reddit</code>. <code>cleanText</code> is now a parameter of <code>AddText.activity.reddit</code> and <code>AddText.actor.reddit</code>.</li>
@@ -382,9 +399,9 @@
 <h1 class="page-header" data-toc-text="0.28.1">
 <a href="#vosonsml-0281" class="anchor"></a>vosonSML 0.28.1<small> Unreleased </small>
 </h1>
-<div id="minor-changes-12" class="section level2">
+<div id="minor-changes-13" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-12" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-13" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added <code>activity</code> network type for reddit. In the reddit activity network nodes are the thread posts and comments, edges represent where comments are directed in the threads.</li>
 <li>Added github dev version badge to README.</li>
@@ -407,9 +424,9 @@
 <h1 class="page-header" data-toc-text="0.27.3">
 <a href="#vosonsml-0273" class="anchor"></a>vosonSML 0.27.3<small> Unreleased </small>
 </h1>
-<div id="minor-changes-13" class="section level2">
+<div id="minor-changes-14" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-13" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-14" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added a new twitter actor network edge type <code>self-loop</code>. This aims to facilitate the later addition of tweet text to the network graph for user tweets that have no ties to other users.</li>
 </ul>
@@ -419,9 +436,9 @@
 <h1 class="page-header" data-toc-text="0.27.2">
 <a href="#vosonsml-0272" class="anchor"></a>vosonSML 0.27.2<small> 2019-07-18 </small>
 </h1>
-<div id="minor-changes-14" class="section level2">
+<div id="minor-changes-15" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-14" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-15" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added twitter interactive web authorization of an app as provided by <code><a href="https://rdrr.io/pkg/rtweet/man/create_token.html">rtweet::create_token</a></code>. Method is used when only twitter app name and consumer keys are passed to <code>Authenticate.twitter</code> as parameters. e.g <code><a href="../reference/Authenticate.html">Authenticate("twitter", appName = "An App", apiKey = "xxxxxxxxxxxx",   apiSecret = "xxxxxxxxxxxx")</a></code>. A browser tab will open asking the user to authorize the app to their twitter account to complete authentication. This is using twitters <code>Application-user authentication: OAuth 1a (access token for user context)</code> method.</li>
 <li>It is suspected that Reddit is rate-limiting some generic R UA strings. So a User-Agent string is now set for underlaying R Collect functions (e.g <code>file</code>) via the <code>HTTPUserAgent</code> option. It is temporarily set to package name and current version number for Collect e.g <code>vosonSML v.0.27.2 (R Package)</code>.</li>
@@ -441,9 +458,9 @@
 <li>Some UTF encoding issues in <code>Create.semantic.twitter</code> were also fixed.</li>
 </ul>
 </div>
-<div id="minor-changes-15" class="section level2">
+<div id="minor-changes-16" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-15" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-16" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added ‘#’ to hashtags and ‘@’ to mentions in twitter semantic network to differentiate between hashtags, mentions and common terms.</li>
 </ul>
@@ -468,9 +485,9 @@
 <li>Changed the way that the <code>cleanText</code> parameter works in <code>Create.actor.reddit</code> so that it is more permissive. Addresses encoding issues with apostrophes and pound symbols and removes unicode characters not permitted by the XML 1.0 standard as used in <code>graphml</code> files. This is best effort and does not resolve all <code>reddit</code> text encoding issues.</li>
 </ul>
 </div>
-<div id="minor-changes-16" class="section level2">
+<div id="minor-changes-17" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-16" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-17" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Added <code>Collect.twitter</code> summary information that includes the earliest (min) and latest (max) tweet <code>status_id</code> collected with timestamp. The <code>status_id</code> values can be used to frame subsequent collections as <code>since_id</code> or <code>max_id</code> parameter values. If the <code>until</code> date parameter was used the timestamp can also be used as a quick confirmation.</li>
 <li>Added elapsed time output to the <code>Collect</code> method.</li>
@@ -488,9 +505,9 @@
 <li>Fixed bugs in <code>Create.actor.reddit</code> that were incorrectly creating edges between top-level commentors and thread authors from different threads. These bugs were only observable in when collecting multiple reddit threads.</li>
 </ul>
 </div>
-<div id="minor-changes-17" class="section level2">
+<div id="minor-changes-18" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-17" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-18" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Improved output for <code>reddit</code> collection. Removed the progress bar and added a table of results summarising the number of comments collected for each thread.</li>
 <li>Added to <code>twitter</code> collection output the users <code>twitter API</code> reset time.</li>
@@ -516,9 +533,9 @@
 <li>Updated all <code>Authenticate</code>, <code>Collect</code> and <code>Create</code> S3 methods to implement function routing based on object class names.</li>
 </ul>
 </div>
-<div id="minor-changes-18" class="section level2">
+<div id="minor-changes-19" class="section level2">
 <h2 class="hasAnchor">
-<a href="#minor-changes-18" class="anchor"></a>Minor Changes</h2>
+<a href="#minor-changes-19" class="anchor"></a>Minor Changes</h2>
 <ul>
 <li>Created a <code>pkgdown</code> web site for github hosted package documentation.</li>
 <li>Created a new hex sticker logo.</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   Intro-to-vosonSML: Intro-to-vosonSML.html
-last_built: 2020-06-14T06:21Z
+last_built: 2020-06-18T12:18Z
 urls:
   reference: http://vosonlab.github.io/vosonSML/reference
   article: http://vosonlab.github.io/vosonSML/articles

--- a/docs/reference/Authenticate.html
+++ b/docs/reference/Authenticate.html
@@ -86,7 +86,7 @@ Authenticate.reddit for parameters and usage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.reddit.html
+++ b/docs/reference/Authenticate.reddit.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.twitter.html
+++ b/docs/reference/Authenticate.twitter.html
@@ -89,7 +89,7 @@ https://developer.twitter.com/en/docs/basics/authentication/overview/oauth." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Authenticate.youtube.html
+++ b/docs/reference/Authenticate.youtube.html
@@ -82,7 +82,7 @@ https://developers.google.com/youtube/v3/docs/." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.html
+++ b/docs/reference/Collect.html
@@ -85,7 +85,7 @@ Collect.reddit for parameters and usage." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.reddit.html
+++ b/docs/reference/Collect.reddit.html
@@ -82,7 +82,7 @@ the data into a dataframe with the class names &quot;datasource&quot; and &quot;
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.twitter.html
+++ b/docs/reference/Collect.twitter.html
@@ -93,7 +93,7 @@ documentation for query operators: https://developer.twitter.com/en/docs/tweets/
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Collect.youtube.html
+++ b/docs/reference/Collect.youtube.html
@@ -90,7 +90,7 @@ https://developers.google.com/youtube/v3/getting-started" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.activity.reddit.html
+++ b/docs/reference/Create.activity.reddit.html
@@ -82,7 +82,7 @@ posts, edges form the discussion structure and signify to which comment or post 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.activity.twitter.html
+++ b/docs/reference/Create.activity.twitter.html
@@ -84,7 +84,7 @@ and will be isolates." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.activity.youtube.html
+++ b/docs/reference/Create.activity.youtube.html
@@ -82,7 +82,7 @@ comments, reply comments and videos. Edges are directed between the nodes and re
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.reddit.html
+++ b/docs/reference/Create.actor.reddit.html
@@ -82,7 +82,7 @@ are actor nodes and comment replies to each other are represented as directed ed
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.twitter.html
+++ b/docs/reference/Create.actor.twitter.html
@@ -84,7 +84,7 @@ without relations to other users will appear in the network graph as isolate nod
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.actor.youtube.html
+++ b/docs/reference/Create.actor.youtube.html
@@ -84,7 +84,7 @@ the videos publisher with top-level comments as directed edges towards them." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.html
+++ b/docs/reference/Create.html
@@ -90,7 +90,7 @@ Create.semantic.twitter functions for parameters and usage respectively." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/Create.semantic.twitter.html
+++ b/docs/reference/Create.semantic.twitter.html
@@ -51,8 +51,11 @@
 <meta property="og:title" content="Create twitter semantic network — Create.semantic.twitter" />
 <meta property="og:description" content="Creates a semantic network from tweets returned from the twitter search query. Semantic networks 
 describe the semantic relationships between concepts. In this network the concepts are significant words and 
-hashtags extracted from the tweet text. Network edges are weighted and represent occurence of words and
-hashtags in the same tweets." />
+hashtags extracted from the tweet text. Network edges are weighted and represent occurrence of words and
+hashtags in the same tweets.
+The creation of twitter semantic networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the tidyr and tidytext packages to achieve
+this." />
 
 
 
@@ -84,7 +87,7 @@ hashtags in the same tweets." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -165,8 +168,11 @@ hashtags in the same tweets." />
     <div class="ref-description">
     <p>Creates a semantic network from tweets returned from the twitter search query. Semantic networks 
 describe the semantic relationships between concepts. In this network the concepts are significant words and 
-hashtags extracted from the tweet text. Network edges are weighted and represent occurence of words and
+hashtags extracted from the tweet text. Network edges are weighted and represent occurrence of words and
 hashtags in the same tweets.</p>
+<p>The creation of twitter semantic networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the <span class="pkg">tidyr</span> and <span class="pkg">tidytext</span> packages to achieve
+this.</p>
     </div>
 
     <pre class="usage"><span class='co'># S3 method for semantic.twitter</span>
@@ -263,7 +269,7 @@ occurring hashtags and terms, hashtags and hashtags, and terms and terms. Defaul
     <p>The words and hashtags passed to the function in the <code>removeTermsOrHashtags</code> parameter are removed
 before word frequencies are calculated and are therefore excluded from top percentage of most frequent terms
 completely rather than simply filtered out of the final network.</p>
-<p>The top percentage of frequently occuring hashtags <code>hashtagFreq</code> and words <code>termFreq</code> are calculated to a
+<p>The top percentage of frequently occurring hashtags <code>hashtagFreq</code> and words <code>termFreq</code> are calculated to a
 minimum frequency and all terms that have an equal or greater frequency than the minimum are included in the network
 as nodes. For example, of unique hashtags of varying frequencies in a dataset the top 50<!-- % of total -->
 frequency or most common hashtags may calculate to being the first 20 hashtags. The frequency of the 20th hashtag is
@@ -276,6 +282,10 @@ them occurring in tweet text with other top percentage frequency terms.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
+<span class='co'># twitter semantic network creation additionally requires the tidyr and tidytext packages</span>
+<span class='co'># for working with text data</span>
+<span class='fu'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"tidytext"</span>, <span class='st'>"tidyr"</span>))
+
 <span class='co'># create a twitter semantic network graph removing the hashtag '#auspol' and using the</span>
 <span class='co'># top 2% frequently occurring words and 10% most frequently occurring hashtags as nodes</span>
 <span class='no'>semanticNetwork</span> <span class='kw'>&lt;-</span> <span class='no'>twitterData</span> <span class='kw'>%&gt;%</span>

--- a/docs/reference/Create.twomode.twitter.html
+++ b/docs/reference/Create.twomode.twitter.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Create twitter twomode network — Create.twomode.twitter • vosonSML</title>
+<title>Create twitter 2-mode network — Create.twomode.twitter • vosonSML</title>
 
 <!-- favicons -->
 <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png">
@@ -48,10 +48,12 @@
   <link href="../extra.css" rel="stylesheet">
   
 
-<meta property="og:title" content="Create twitter twomode network — Create.twomode.twitter" />
-<meta property="og:description" content="Creates a twomode network from tweets returned from the twitter search query. In this network there are 
+<meta property="og:title" content="Create twitter 2-mode network — Create.twomode.twitter" />
+<meta property="og:description" content="Creates a 2-mode network from tweets returned from the twitter search query. In this network there are 
 two types of nodes, twitter users who authored or were mentioned in collected tweets and hashtags found within
-tweets. Network edges represent a users tweets that contain hashtags or mention users screen names." />
+tweets. Network edges represent a users tweets that contain hashtags or mention users screen names.
+The creation of twitter 2-mode networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the tidytext package to achieve this." />
 
 
 
@@ -83,7 +85,7 @@ tweets. Network edges represent a users tweets that contain hashtags or mention 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -156,15 +158,17 @@ tweets. Network edges represent a users tweets that contain hashtags or mention 
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Create twitter twomode network</h1>
+    <h1>Create twitter 2-mode network</h1>
     <small class="dont-index">Source: <a href='https://github.com/vosonlab/vosonSML/blob/master/R/Create.twomode.twitter.R'><code>R/Create.twomode.twitter.R</code></a></small>
     <div class="hidden name"><code>Create.twomode.twitter.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>Creates a twomode network from tweets returned from the twitter search query. In this network there are 
+    <p>Creates a 2-mode network from tweets returned from the twitter search query. In this network there are 
 two types of nodes, twitter users who authored or were mentioned in collected tweets and hashtags found within
 tweets. Network edges represent a users tweets that contain hashtags or mention users screen names.</p>
+<p>The creation of twitter 2-mode networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the <span class="pkg">tidytext</span> package to achieve this.</p>
     </div>
 
     <pre class="usage"><span class='co'># S3 method for twomode.twitter</span>
@@ -215,7 +219,11 @@ nodes with matching name. Default is <code>NULL</code> to remove none.</p></td>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
-<span class='co'># create a twitter twomode network graph removing the hashtag '#auspol' as it was used in </span>
+<span class='co'># twitter 2-mode network creation additionally requires the tidytext package</span>
+<span class='co'># for working with text data</span>
+<span class='fu'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span>(<span class='st'>"tidytext"</span>)
+
+<span class='co'># create a twitter 2-mode network graph removing the hashtag '#auspol' as it was used in </span>
 <span class='co'># the twitter search query</span>
 <span class='no'>twomodeNetwork</span> <span class='kw'>&lt;-</span> <span class='no'>twitterData</span> <span class='kw'>%&gt;%</span>
                   <span class='fu'><a href='Create.html'>Create</a></span>(<span class='st'>"twomode"</span>, <span class='kw'>removeTermsOrHashtags</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"#auspol"</span>), <span class='kw'>verbose</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>)

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -80,7 +80,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 
@@ -316,7 +316,7 @@
         <td>
           <p><code><a href="Create.twomode.twitter.html">Create(<i>&lt;twomode.twitter&gt;</i>)</a></code> </p>
         </td>
-        <td><p>Create twitter twomode network</p></td>
+        <td><p>Create twitter 2-mode network</p></td>
       </tr><tr>
         
         <td>

--- a/docs/reference/vosonSML-colon-colon-AddText.activity.reddit.html
+++ b/docs/reference/vosonSML-colon-colon-AddText.activity.reddit.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddText.actor.reddit.html
+++ b/docs/reference/vosonSML-colon-colon-AddText.actor.reddit.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddText.actor.youtube.html
+++ b/docs/reference/vosonSML-colon-colon-AddText.actor.youtube.html
@@ -83,7 +83,7 @@ differ from the top-level comment author." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddText.html
+++ b/docs/reference/vosonSML-colon-colon-AddText.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddUserData.actor.twitter.html
+++ b/docs/reference/vosonSML-colon-colon-AddUserData.actor.twitter.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddUserData.html
+++ b/docs/reference/vosonSML-colon-colon-AddUserData.html
@@ -82,7 +82,7 @@ attributes." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddVideoData.actor.youtube.html
+++ b/docs/reference/vosonSML-colon-colon-AddVideoData.actor.youtube.html
@@ -84,7 +84,7 @@ the video details." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-AddVideoData.html
+++ b/docs/reference/vosonSML-colon-colon-AddVideoData.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html
+++ b/docs/reference/vosonSML-colon-colon-GetYoutubeVideoIDs.html
@@ -84,7 +84,7 @@ parameter." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-Graph.html
+++ b/docs/reference/vosonSML-colon-colon-Graph.html
@@ -81,7 +81,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-colon-colon-ImportData.html
+++ b/docs/reference/vosonSML-colon-colon-ImportData.html
@@ -82,7 +82,7 @@ socialmedia type that is usable by Create functions." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/docs/reference/vosonSML-package.html
+++ b/docs/reference/vosonSML-package.html
@@ -93,7 +93,7 @@ the Create function resulting in a twitter network (as igraph object) that is re
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">vosonSML</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.12</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.29.13</span>
       </span>
     </div>
 

--- a/man/Create.semantic.twitter.Rd
+++ b/man/Create.semantic.twitter.Rd
@@ -65,15 +65,19 @@ Network as a named list of two dataframes containing \code{$nodes} and \code{$ed
 \description{
 Creates a semantic network from tweets returned from the twitter search query. Semantic networks 
 describe the semantic relationships between concepts. In this network the concepts are significant words and 
-hashtags extracted from the tweet text. Network edges are weighted and represent occurence of words and
+hashtags extracted from the tweet text. Network edges are weighted and represent occurrence of words and
 hashtags in the same tweets.
+
+The creation of twitter semantic networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the \pkg{tidyr} and \pkg{tidytext} packages to achieve
+this.
 }
 \note{
 The words and hashtags passed to the function in the \code{removeTermsOrHashtags} parameter are removed
 before word frequencies are calculated and are therefore excluded from top percentage of most frequent terms
 completely rather than simply filtered out of the final network.
 
-The top percentage of frequently occuring hashtags \code{hashtagFreq} and words \code{termFreq} are calculated to a
+The top percentage of frequently occurring hashtags \code{hashtagFreq} and words \code{termFreq} are calculated to a
 minimum frequency and all terms that have an equal or greater frequency than the minimum are included in the network
 as nodes. For example, of unique hashtags of varying frequencies in a dataset the top 50% of total
 frequency or most common hashtags may calculate to being the first 20 hashtags. The frequency of the 20th hashtag is
@@ -87,6 +91,10 @@ them occurring in tweet text with other top percentage frequency terms.
 }
 \examples{
 \dontrun{
+# twitter semantic network creation additionally requires the tidyr and tidytext packages
+# for working with text data
+install.packages(c("tidytext", "tidyr"))
+
 # create a twitter semantic network graph removing the hashtag '#auspol' and using the
 # top 2\% frequently occurring words and 10\% most frequently occurring hashtags as nodes
 semanticNetwork <- twitterData \%>\% 

--- a/man/Create.twomode.twitter.Rd
+++ b/man/Create.twomode.twitter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Create.twomode.twitter.R
 \name{Create.twomode.twitter}
 \alias{Create.twomode.twitter}
-\title{Create twitter twomode network}
+\title{Create twitter 2-mode network}
 \usage{
 \method{Create}{twomode.twitter}(
   datasource,
@@ -33,13 +33,20 @@ nodes with matching name. Default is \code{NULL} to remove none.}
 Network as a named list of two dataframes containing \code{$nodes} and \code{$edges}.
 }
 \description{
-Creates a twomode network from tweets returned from the twitter search query. In this network there are 
+Creates a 2-mode network from tweets returned from the twitter search query. In this network there are 
 two types of nodes, twitter users who authored or were mentioned in collected tweets and hashtags found within
 tweets. Network edges represent a users tweets that contain hashtags or mention users screen names.
+
+The creation of twitter 2-mode networks requires text processing and the tokenization of tweets. As such
+this function requires the additional installation of the \pkg{tidytext} package to achieve this.
 }
 \examples{
 \dontrun{
-# create a twitter twomode network graph removing the hashtag '#auspol' as it was used in 
+# twitter 2-mode network creation additionally requires the tidytext package
+# for working with text data
+install.packages("tidytext")
+
+# create a twitter 2-mode network graph removing the hashtag '#auspol' as it was used in 
 # the twitter search query
 twomodeNetwork <- twitterData \%>\% 
                   Create("twomode", removeTermsOrHashtags = c("#auspol"), verbose = TRUE)

--- a/vignettes/Intro-to-vosonSML.Rmd
+++ b/vignettes/Intro-to-vosonSML.Rmd
@@ -110,7 +110,7 @@ twitterData <- ImportData("/path/to/data/data.rds", "twitter")
 
 ## Creating Twitter Networks
 
-It is currently possible to create four types of networks using Twitter data: (1) *actor network*; (2) *activity network*; (3) *two-mode network* and (4) *semantic network*. 
+It is currently possible to create four types of networks using Twitter data: (1) *actor network*; (2) *activity network*; (3) *2-mode network* and (4) *semantic network*. 
 
 ### Actor Network 
 
@@ -289,9 +289,9 @@ dev.off()
 
 It should be noted that a limitation of the Twitter API is that retweet chains are not provided. That is: if user *i* tweeted an original tweet, and then user *j* retweeted this tweet, and user *k* retweeted *j*'s retweet, the activity network will show edges connecting the two retweets to the original tweet.
 
-### Two-mode Network
+### 2-mode Network
 
-In the Twitter *two-mode network*, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user *i* to hashtag *j* if user *i* authored a tweet containing hashtag *j*. 
+In the Twitter *2-mode network*, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user *i* to hashtag *j* if user *i* authored a tweet containing hashtag *j*. 
 
 ```{r eval=FALSE}
 twomodeNetwork <- twitterData %>% Create("twomode", removeTermsOrHashtags = c("#auspol"))
@@ -340,7 +340,7 @@ IGRAPH 68bd240 DN-- 1146 1675 --
 + ... omitted several edges
 ```
 
-The Twitter two-model network has a graph attribute `type` (set to "twitter"). The node attributes are: `name` (hashtag or Twitter user ID), `display_name` (hashtag or Twitter handle or screen name), `label` (for users, a concatenation of `name` and `display_name`, while for hashtags it is `name`). The edge attributes are: `edge_type` ('hashtag'), `timestamp` (timestamp of the tweet that led to the edge), `status_id` (Twitter ID of the tweet that led to the edge).
+The Twitter 2-model network has a graph attribute `type` (set to "twitter"). The node attributes are: `name` (hashtag or Twitter user ID), `display_name` (hashtag or Twitter handle or screen name), `label` (for users, a concatenation of `name` and `display_name`, while for hashtags it is `name`). The edge attributes are: `edge_type` ('hashtag'), `timestamp` (timestamp of the tweet that led to the edge), `status_id` (Twitter ID of the tweet that led to the edge).
 
 ```{r eval=FALSE}
 ind <- order(degree(twomodeGraph, mode="in"), decreasing=TRUE)[1:5] # top-5 hashtags
@@ -356,7 +356,7 @@ plot(g2, vertex.label=V(g2)$label2, vertex.size=4, edge.arrow.size=0.5, vertex.l
 dev.off()
 ```
 
-![Twitter twomode network - top-5 hashtags, and the users who tweeted them](https://vosonlab.github.io/vosonSML/images/intro-to-vosonsml/twitter_twomode.png)
+![Twitter 2-mode network - top-5 hashtags, and the users who tweeted them](https://vosonlab.github.io/vosonSML/images/intro-to-vosonsml/twitter_twomode.png)
 
 
 ### Semantic Network 


### PR DESCRIPTION
Minor updates:
- Minor documentation updates to `README`, `Create.semantic.twitter`, `Create.twomode.twitter` and the `Intro-to-vosonSML` vignette:
    - Specified the `tidyr` and `tidytext` package requirements in descriptions and examples
    - Updated references to `twomode` networks as `2-mode` where possible