### PR TITLE
CRAN package version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
 Suggests:
     knitr,
     rmarkdown,
+    stopwords,
     testthat,
     tictoc,
     tidyr,
@@ -37,7 +38,7 @@ Encoding: UTF-8
 Author: Timothy Graham, Robert Ackland, Chung-hong Chan, Bryan Gertzel
 Maintainer: Bryan Gertzel <bryan.gertzel@anu.edu.au>
 License: GPL (>= 3)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 NeedsCompilation: no
 VignetteBuilder: knitr
 URL: https://github.com/vosonlab/vosonSML

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Minor Changes
 - Minor documentation updates to `Create.semantic.twitter`, `Create.twomode.twitter` and the `Intro-to-vosonSML` vignette:
-    - Specified the `tidyr` and `tidytext` package requirements in descriptions and examples
+    - Specified the `tidyr`, `tidytext` and `stopwords` package requirements in descriptions and examples
     - Updated references to `twomode` networks as `2-mode` where possible
 
 # vosonSML 0.29.12

--- a/R/Create.semantic.twitter.R
+++ b/R/Create.semantic.twitter.R
@@ -55,9 +55,9 @@
 #' 
 #' @examples
 #' \dontrun{
-#' # twitter semantic network creation additionally requires the tidyr and tidytext packages
+#' # twitter semantic network creation additionally requires the tidyr, tidytext and stopwords packages
 #' # for working with text data
-#' install.packages(c("tidytext", "tidyr"))
+#' install.packages(c("tidyr", "tidytext", "stopwords"))
 #' 
 #' # create a twitter semantic network graph removing the hashtag '#auspol' and using the
 #' # top 2% frequently occurring words and 10% most frequently occurring hashtags as nodes

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Unfortunately we are no longer able to maintain `facebook` and `instagram` colle
 
 ## Installation
 
-Install the latest release via CRAN (v0.29.10):
+Install the latest release via CRAN (v0.29.13):
 ``` r
 install.packages("vosonSML")
 ```
 
-Install the latest release via GitHub (v0.29.12):
+Install the latest release via GitHub (v0.29.13):
 ``` r
-install.packages("https://github.com/vosonlab/vosonSML/releases/download/v0.29.12/vosonSML-0.29.12.tar.gz",
+install.packages("https://github.com/vosonlab/vosonSML/releases/download/v0.29.13/vosonSML-0.29.13.tar.gz",
   repo = NULL, type = "source")
 ```
 
@@ -168,7 +168,7 @@ actorNetwork <- twitterData %>%
 
 Nodes are concepts represented as common words and hashtags, edges represent the occurence of a word and hashtag in the same tweet.
 ``` r
-install.packages(c("tidytext", "tidyr")) # install additional required packages
+install.packages(c("tidyr", "tidytext", "stopwords")) # install additional required packages
 
 # create a semantic network excluding the hashtag #auspol, include only the top 10%
 # most frequent words and 20% most frequent hashtags as nodes
@@ -187,22 +187,22 @@ semanticNetwork <- twitterData %>%
 #> -------------------------
 #> collected tweets           | 100
 #> tokens                     | 2737
-#> removed specified          | 95 
-#> removed users              | 97 
-#> hashtag count              | 82 
-#> unique hashtags            | 60 
-#> top 20% hashtags (freq>=2) | 13 
+#> removed specified          | 95
+#> removed users              | 97
+#> hashtag count              | 82
+#> unique hashtags            | 60
+#> top 20% hashtags (freq>=2) | 13
 #> term count                 | 1159
 #> unique terms               | 836
 #> top 10% terms (freq>=2)    | 186
 #> nodes                      | 199
-#> edges                      | 95 
+#> edges                      | 95
 #> -------------------------
 #> Done.
 #> Creating igraph network graph...
 #> GRAPHML file written: D:/wd/2020-04-20_003304-TwitterSemantic.graphml
 #> Done.
-#> IGRAPH ae1da92 UNWB 199 95 -- 
+#> IGRAPH ae1da92 UNWB 199 95 --
 #> + attr: type (g/c), name (v/c), n (v/n), type (v/c), label (v/c), weight (e/n)
 ```
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,8 @@
 ## Test environments
-* local MacOS X, R 4.0.0
+* local MacOS X, R 4.0.2
 * local Windows 10, R 4.0.2
-* R-Devel r78868 Windows (Winbuilder)
 * Winbuilder (R-release, R-oldrelease)
+* R-Devel r78868 Windows (Winbuilder)
 
 ## R CMD check results
 0 errors | 0 warnings

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,12 @@
 ## Test environments
-* local MacOS X, R 3.6.0
-* local Windows 10, R 3.6.3
-* R-Devel r78276 Windows (Winbuilder)
+* local MacOS X, R 4.0.0
+* local Windows 10, R 4.0.2
+* R-Devel r78868 Windows (Winbuilder)
+* Winbuilder (R-release, R-oldrelease)
 
 ## R CMD check results
 0 errors | 0 warnings
+
+R-Devel error:
+* checking package dependencies ... ERROR
+Package required but not available: 'igraph'

--- a/docs/articles/Intro-to-vosonSML.html
+++ b/docs/articles/Intro-to-vosonSML.html
@@ -108,14 +108,14 @@
 
       
 
-      </header><script src="Intro-to-vosonSML_files/header-attrs-2.2/header-attrs.js"></script><div class="row">
+      </header><script src="Intro-to-vosonSML_files/header-attrs-2.3/header-attrs.js"></script><script src="Intro-to-vosonSML_files/accessible-code-block-0.0.1/empty-anchor.js"></script><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>Introduction to vosonSML</h1>
             <h3 class="subtitle">VOSON Lab, Australian National University</h3>
                         <h4 class="author">Robert Ackland, Bryan Gertzel, Francisca Borquez</h4>
             
-            <h4 class="date">18 June, 2020</h4>
+            <h4 class="date">17 July, 2020</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/vosonlab/vosonSML/blob/master/vignettes/Intro-to-vosonSML.Rmd"><code>vignettes/Intro-to-vosonSML.Rmd</code></a></small>
       <div class="hidden name"><code>Intro-to-vosonSML.Rmd</code></div>
@@ -327,7 +327,10 @@ IGRAPH e60c486 DN-- 1408 662 --
 <h3 class="hasAnchor">
 <a href="#mode-network" class="anchor"></a>2-mode Network</h3>
 <p>In the Twitter <em>2-mode network</em>, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user <em>i</em> to hashtag <em>j</em> if user <em>i</em> authored a tweet containing hashtag <em>j</em>.</p>
-<div class="sourceCode" id="cb22"><html><body><pre class="r"><span class="no">twomodeNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/Create.html">Create</a></span>(<span class="st">"twomode"</span>, <span class="kw">removeTermsOrHashtags</span> <span class="kw">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"#auspol"</span>))
+<div class="sourceCode" id="cb22"><html><body><pre class="r"><span class="co"># additional required packages</span>
+<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"tidytext"</span>)
+
+<span class="no">twomodeNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/Create.html">Create</a></span>(<span class="st">"twomode"</span>, <span class="kw">removeTermsOrHashtags</span> <span class="kw">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"#auspol"</span>))
 <span class="no">twomodeGraph</span> <span class="kw">&lt;-</span> <span class="no">twomodeNetwork</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/vosonSML-colon-colon-Graph.html">Graph</a></span>(<span class="kw">writeToFile</span> <span class="kw">=</span> <span class="fl">TRUE</span>)</pre></body></html></div>
 <p><code><a href="../reference/Create.html">Create("twomode")</a></code> returns a named list containing two dataframes named “nodes” and “edges” (the following has been modified to preserve anonymity). Note that in this example, the <code>removeTermsOrHashtags</code> argument was used to exclude ‘#auspol’, since by construction all tweets contained this hashtag.</p>
 <div class="sourceCode" id="cb23"><html><body><pre class="r">&gt; twomodeNetwork
@@ -383,7 +386,10 @@ IGRAPH 68bd240 DN-- 1146 1675 --
 <h3 class="hasAnchor">
 <a href="#semantic-network" class="anchor"></a>Semantic Network</h3>
 <p>In the Twitter <em>semantic network</em>, nodes represent entities extracted from the tweet text: common words, hashtags and usernames. Edges reflect co-occurrence i.e. there is an edge between entities <em>i</em> and <em>j</em> if they both occurred in the same tweet.</p>
-<div class="sourceCode" id="cb26"><html><body><pre class="r"><span class="no">semanticNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/Create.html">Create</a></span>(<span class="st">"semantic"</span>,
+<div class="sourceCode" id="cb26"><html><body><pre class="r"><span class="co"># additional required packages</span>
+<span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"tidyr"</span>, <span class="st">"tidytext"</span>, <span class="st">"stopwords"</span>))
+
+<span class="no">semanticNetwork</span> <span class="kw">&lt;-</span> <span class="no">twitterData</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/Create.html">Create</a></span>(<span class="st">"semantic"</span>,
                                           <span class="kw">removeTermsOrHashtags</span> <span class="kw">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"#auspol"</span>, <span class="st">"auspol"</span>, <span class="st">"australia"</span>),
                                           <span class="kw">termFreq</span> <span class="kw">=</span> <span class="fl">5</span>)
 <span class="no">semanticGraph</span> <span class="kw">&lt;-</span> <span class="no">semanticNetwork</span> <span class="kw">%&gt;%</span> <span class="fu"><a href="../reference/vosonSML-colon-colon-Graph.html">Graph</a></span>(<span class="kw">writeToFile</span> <span class="kw">=</span> <span class="fl">TRUE</span>, <span class="kw">directed</span> <span class="kw">=</span> <span class="fl">FALSE</span>)</pre></body></html></div>

--- a/docs/articles/Intro-to-vosonSML_files/accessible-code-block-0.0.1/empty-anchor.js
+++ b/docs/articles/Intro-to-vosonSML_files/accessible-code-block-0.0.1/empty-anchor.js
@@ -1,0 +1,15 @@
+// Hide empty <a> tag within highlighted CodeBlock for screen reader accessibility (see https://github.com/jgm/pandoc/issues/6352#issuecomment-626106786) -->
+// v0.0.1
+// Written by JooYoung Seo (jooyoung@psu.edu) and Atsushi Yasumoto on June 1st, 2020.
+
+document.addEventListener('DOMContentLoaded', function() {
+  const codeList = document.getElementsByClassName("sourceCode");
+  for (var i = 0; i < codeList.length; i++) {
+    var linkList = codeList[i].getElementsByTagName('a');
+    for (var j = 0; j < linkList.length; j++) {
+      if (linkList[j].innerHTML === "") {
+        linkList[j].setAttribute('aria-hidden', 'true');
+      }
+    }
+  }
+});

--- a/docs/articles/Intro-to-vosonSML_files/header-attrs-2.3/header-attrs.js
+++ b/docs/articles/Intro-to-vosonSML_files/header-attrs-2.3/header-attrs.js
@@ -1,0 +1,12 @@
+// Pandoc 2.9 adds attributes on both header and div. We remove the former (to
+// be compatible with the behavior of Pandoc < 2.8).
+document.addEventListener('DOMContentLoaded', function(e) {
+  var hs = document.querySelectorAll("div.section[class*='level'] > :first-child");
+  var i, h, a;
+  for (i = 0; i < hs.length; i++) {
+    h = hs[i];
+    if (!/^h[1-6]$/i.test(h.tagName)) continue;  // it should be a header h1-h6
+    a = h.attributes;
+    while (a.length > 0) h.removeAttribute(a[0].name);
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,10 +128,10 @@
 <div id="installation" class="section level2">
 <h2 class="hasAnchor">
 <a href="#installation" class="anchor"></a>Installation</h2>
-<p>Install the latest release via CRAN (v0.29.10):</p>
+<p>Install the latest release via CRAN (v0.29.13):</p>
 <div class="sourceCode" id="cb1"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"vosonSML"</span>)</pre></div>
-<p>Install the latest release via GitHub (v0.29.12):</p>
-<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/vosonSML/releases/download/v0.29.12/vosonSML-0.29.12.tar.gz"</span>,
+<p>Install the latest release via GitHub (v0.29.13):</p>
+<div class="sourceCode" id="cb2"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="st">"https://github.com/vosonlab/vosonSML/releases/download/v0.29.13/vosonSML-0.29.13.tar.gz"</span>,
   <span class="kw">repo</span> <span class="kw">=</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="kw">=</span> <span class="st">"source"</span>)</pre></div>
 <p>Install the latest development version (v0.29.13):</p>
 <div class="sourceCode" id="cb3"><pre class="r"><span class="co"># library(devtools)</span>
@@ -259,7 +259,7 @@
 <h5 class="hasAnchor">
 <a href="#semantic-network" class="anchor"></a>Semantic network</h5>
 <p>Nodes are concepts represented as common words and hashtags, edges represent the occurence of a word and hashtag in the same tweet.</p>
-<div class="sourceCode" id="cb12"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"tidytext"</span>, <span class="st">"tidyr"</span>)) <span class="co"># install additional required packages</span>
+<div class="sourceCode" id="cb12"><pre class="r"><span class="fu"><a href="https://rdrr.io/r/utils/install.packages.html">install.packages</a></span>(<span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span>(<span class="st">"tidyr"</span>, <span class="st">"tidytext"</span>, <span class="st">"stopwords"</span>)) <span class="co"># install additional required packages</span>
 
 <span class="co"># create a semantic network excluding the hashtag #auspol, include only the top 10%</span>
 <span class="co"># most frequent words and 20% most frequent hashtags as nodes</span>
@@ -276,22 +276,22 @@
 #&gt; -------------------------
 #&gt; collected tweets           | 100
 #&gt; tokens                     | 2737
-#&gt; removed specified          | 95 
-#&gt; removed users              | 97 
-#&gt; hashtag count              | 82 
-#&gt; unique hashtags            | 60 
-#&gt; top 20% hashtags (freq&gt;=2) | 13 
+#&gt; removed specified          | 95
+#&gt; removed users              | 97
+#&gt; hashtag count              | 82
+#&gt; unique hashtags            | 60
+#&gt; top 20% hashtags (freq&gt;=2) | 13
 #&gt; term count                 | 1159
 #&gt; unique terms               | 836
 #&gt; top 10% terms (freq&gt;=2)    | 186
 #&gt; nodes                      | 199
-#&gt; edges                      | 95 
+#&gt; edges                      | 95
 #&gt; -------------------------
 #&gt; Done.
 #&gt; Creating igraph network graph...
 #&gt; GRAPHML file written: D:/wd/2020-04-20_003304-TwitterSemantic.graphml
 #&gt; Done.
-#&gt; IGRAPH ae1da92 UNWB 199 95 -- 
+#&gt; IGRAPH ae1da92 UNWB 199 95 --
 #&gt; + attr: type (g/c), name (v/c), n (v/n), type (v/c), label (v/c), weight (e/n)</pre></div>
 </div>
 <div id="2-mode-network" class="section level5">

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -167,7 +167,7 @@
 <ul>
 <li>Minor documentation updates to <code>Create.semantic.twitter</code>, <code>Create.twomode.twitter</code> and the <code>Intro-to-vosonSML</code> vignette:
 <ul>
-<li>Specified the <code>tidyr</code> and <code>tidytext</code> package requirements in descriptions and examples</li>
+<li>Specified the <code>tidyr</code>, <code>tidytext</code> and <code>stopwords</code> package requirements in descriptions and examples</li>
 <li>Updated references to <code>twomode</code> networks as <code>2-mode</code> where possible</li>
 </ul>
 </li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   Intro-to-vosonSML: Intro-to-vosonSML.html
-last_built: 2020-06-18T12:18Z
+last_built: 2020-07-17T08:02Z
 urls:
   reference: http://vosonlab.github.io/vosonSML/reference
   article: http://vosonlab.github.io/vosonSML/articles

--- a/docs/reference/Create.semantic.twitter.html
+++ b/docs/reference/Create.semantic.twitter.html
@@ -282,9 +282,9 @@ them occurring in tweet text with other top percentage frequency terms.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='kw'>if</span> (<span class='fl'>FALSE</span>) {
-<span class='co'># twitter semantic network creation additionally requires the tidyr and tidytext packages</span>
+<span class='co'># twitter semantic network creation additionally requires the tidyr, tidytext and stopwords packages</span>
 <span class='co'># for working with text data</span>
-<span class='fu'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"tidytext"</span>, <span class='st'>"tidyr"</span>))
+<span class='fu'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"tidyr"</span>, <span class='st'>"tidytext"</span>, <span class='st'>"stopwords"</span>))
 
 <span class='co'># create a twitter semantic network graph removing the hashtag '#auspol' and using the</span>
 <span class='co'># top 2% frequently occurring words and 10% most frequently occurring hashtags as nodes</span>

--- a/man/Create.semantic.twitter.Rd
+++ b/man/Create.semantic.twitter.Rd
@@ -91,9 +91,9 @@ them occurring in tweet text with other top percentage frequency terms.
 }
 \examples{
 \dontrun{
-# twitter semantic network creation additionally requires the tidyr and tidytext packages
+# twitter semantic network creation additionally requires the tidyr, tidytext and stopwords packages
 # for working with text data
-install.packages(c("tidytext", "tidyr"))
+install.packages(c("tidyr", "tidytext", "stopwords"))
 
 # create a twitter semantic network graph removing the hashtag '#auspol' and using the
 # top 2\% frequently occurring words and 10\% most frequently occurring hashtags as nodes

--- a/vignettes/Intro-to-vosonSML.Rmd
+++ b/vignettes/Intro-to-vosonSML.Rmd
@@ -294,6 +294,9 @@ It should be noted that a limitation of the Twitter API is that retweet chains a
 In the Twitter *2-mode network*, the two types of nodes are actors (Twitter users) and hashtags. There is an edge from user *i* to hashtag *j* if user *i* authored a tweet containing hashtag *j*. 
 
 ```{r eval=FALSE}
+# additional required packages
+install.packages("tidytext")
+
 twomodeNetwork <- twitterData %>% Create("twomode", removeTermsOrHashtags = c("#auspol"))
 twomodeGraph <- twomodeNetwork %>% Graph(writeToFile = TRUE)
 ``` 
@@ -364,6 +367,9 @@ dev.off()
 In the Twitter *semantic network*, nodes represent entities extracted from the tweet text: common words, hashtags and usernames. Edges reflect co-occurrence i.e. there is an edge between entities *i* and *j* if they both occurred in the same tweet. 
 
 ```{r eval=FALSE}
+# additional required packages
+install.packages(c("tidyr", "tidytext", "stopwords"))
+
 semanticNetwork <- twitterData %>% Create("semantic",
                                           removeTermsOrHashtags = c("#auspol", "auspol", "australia"),
                                           termFreq = 5)


### PR DESCRIPTION
Version 0.29.11-13

Bug Fixes:
- Fixed an issue with custom class order assigned to dataframes causing a `vctrs` error when using `dplyr` functions. The classes are no longer needed post-method routing so they are simply removed.
- Replaced an instance of the deprecated `dplyr::funs` function that was generating a warning.
- Fixed a reddit collect `bind_rows` error on joining dataframes with different types for the structure column. Column type was being set to integer instead of character in cases when every thread comment have no replies or depth (except the OP).

Minor Changes:
- Minor documentation updates to Create.semantic.twitter, Create.twomode.twitter and the Intro-to-vosonSML vignette:
  - Specified the `tidyr`, `tidytext` and `stopwords` package requirements in descriptions and examples
  - Updated references to `twomode` networks as `2-mode` where possible